### PR TITLE
fix: 修复移动端banner遮蔽导航按钮的问题

### DIFF
--- a/apps/wiki/app/globals.css
+++ b/apps/wiki/app/globals.css
@@ -138,6 +138,7 @@
 :root {
   --background: var(--color-base-100);
   --foreground: var(--color-base-content);
+  --bottom-banner-height: 0px;
 }
 
 html {

--- a/apps/wiki/components/BottomBanner.tsx
+++ b/apps/wiki/components/BottomBanner.tsx
@@ -1,13 +1,13 @@
-"use client";
+'use client';
 
-import { useAtom } from "jotai";
-import { useEffect, useRef } from "react";
-import { Link } from "@/components/progress/next";
+import { Link } from '@/components/progress/next';
+import { useAtom } from 'jotai';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import {
+  bannerHeightAtom,
   bannerVisibilityAtom,
   closeBannerAtom,
-  bannerHeightAtom,
-} from "../lib/banner-atoms";
+} from '../lib/banner-atoms';
 
 interface BottomBannerProps {
   language: string;
@@ -34,25 +34,45 @@ export default function BottomBanner({
     }
   };
 
-  // 监听 banner 高度变化
-  useEffect(() => {
+  // 同步 banner 高度给其他组件，并暴露到 CSS 变量
+  useLayoutEffect(() => {
+    const element = bannerRef.current;
+    if (!element) {
+      return;
+    }
+
+    const root = document.documentElement;
+
     const updateHeight = () => {
-      if (bannerRef.current && isVisible) {
-        setBannerHeight(bannerRef.current.offsetHeight);
-      } else {
-        setBannerHeight(0);
-      }
+      const nextHeight = isVisible ? element.offsetHeight : 0;
+      setBannerHeight(nextHeight);
+      root.style.setProperty('--bottom-banner-height', `${nextHeight}px`);
     };
 
     updateHeight();
 
-    // 监听窗口大小变化，可能会影响 banner 高度
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(updateHeight)
+        : null;
+
+    resizeObserver?.observe(element);
     window.addEventListener('resize', updateHeight);
-    
+
     return () => {
+      resizeObserver?.disconnect();
       window.removeEventListener('resize', updateHeight);
-      setBannerHeight(0);
     };
+  }, [isVisible, setBannerHeight]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      setBannerHeight(0);
+      document.documentElement.style.setProperty(
+        '--bottom-banner-height',
+        '0px',
+      );
+    }
   }, [isVisible, setBannerHeight]);
 
   //console.log("BottomBanner", isVisible, enableCloseButton);
@@ -60,10 +80,11 @@ export default function BottomBanner({
     <div
       ref={bannerRef}
       className={`
-        ${isVisible ? "sticky" : "block"}
-          bottom-0 left-0 right-0 z-40 
-        bg-[#444] text-white shadow-lg
+        fixed bottom-0 left-0 right-0 z-40
+        bg-[#444] text-white shadow-lg transition-transform duration-200
+        ${isVisible ? 'translate-y-0' : 'translate-y-full pointer-events-none'}
       `}
+      aria-hidden={!isVisible}
     >
       <div className="container mx-auto px-4 py-3">
         <div className="flex items-center justify-between gap-4">

--- a/apps/wiki/components/MobileSidebar.tsx
+++ b/apps/wiki/components/MobileSidebar.tsx
@@ -160,7 +160,9 @@ export default function MobileSidebar({
 
   // 计算按钮的底部位置，如果有 banner 就在 banner 上方
   const buttonBottomPosition =
-    bannerHeight > 0 ? `${bannerHeight + 24}px` : '24px';
+    bannerHeight > 0
+      ? `${bannerHeight + 24}px`
+      : 'calc(var(--bottom-banner-height, 0px) + 24px)';
 
   return (
     <>
@@ -168,7 +170,7 @@ export default function MobileSidebar({
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="fixed left-6 z-40 lg:hidden flex items-center space-x-2 px-4 py-3 rounded-full bg-primary text-primary-content shadow-lg hover:bg-primary/90 transition-all duration-200 hover:scale-105"
+        className="fixed left-6 z-50 lg:hidden flex items-center space-x-2 px-4 py-3 rounded-full bg-primary text-primary-content shadow-lg hover:bg-primary/90 transition-all duration-200 hover:scale-105"
         style={{ bottom: buttonBottomPosition }}
         aria-label={t('docs', language)}
       >

--- a/apps/wiki/components/MobileTableOfContents.tsx
+++ b/apps/wiki/components/MobileTableOfContents.tsx
@@ -109,7 +109,9 @@ export default function MobileTableOfContents({
 
   // 计算按钮的底部位置，如果有 banner 就在 banner 上方
   const buttonBottomPosition =
-    bannerHeight > 0 ? `${bannerHeight + 24}px` : '24px';
+    bannerHeight > 0
+      ? `${bannerHeight + 24}px`
+      : 'calc(var(--bottom-banner-height, 0px) + 24px)';
 
   return (
     <>
@@ -117,7 +119,7 @@ export default function MobileTableOfContents({
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="fixed right-6 z-40 xl:hidden p-3 rounded-full bg-base-200/80 backdrop-blur-sm text-base-content shadow-lg hover:bg-base-200 transition-all duration-200 hover:scale-105 border border-base-300/50"
+        className="fixed right-6 z-50 xl:hidden p-3 rounded-full bg-base-200/80 backdrop-blur-sm text-base-content shadow-lg hover:bg-base-200 transition-all duration-200 hover:scale-105 border border-base-300/50"
         style={{ bottom: buttonBottomPosition }}
         aria-label={t('tableOfContents', language)}
       >

--- a/apps/wiki/lib/banner-atoms.ts
+++ b/apps/wiki/lib/banner-atoms.ts
@@ -10,23 +10,23 @@ export interface BannerCloseData {
 
 // Banner 关闭状态 atom (存储在本地存储中)
 export const bannerCloseAtom = atomWithStorage<BannerCloseData>(
-  'mtf-wiki-banner-close', 
-  { closedAt: 0 }
+  'mtf-wiki-banner-close-v2',
+  { closedAt: 0 },
 );
 
 // 计算 banner 是否应该显示的 derived atom
 export const bannerVisibilityAtom = atom<boolean>((get) => {
   const closeData = get(bannerCloseAtom);
-    
+
   // 检查是否已经过了一个月 (30天)
   const oneMonthMs = 30 * 24 * 60 * 60 * 1000;
   const now = Date.now();
-  
+
   if (now - closeData.closedAt > oneMonthMs) {
     // 超过一个月，重置状态
     return true;
   }
-  
+
   return false;
 });
 
@@ -34,11 +34,8 @@ export const bannerVisibilityAtom = atom<boolean>((get) => {
 export const bannerHeightAtom = atom<number>(0);
 
 // 关闭 banner 的 action atom
-export const closeBannerAtom = atom(
-  null,
-  (get, set) => {
-    set(bannerCloseAtom, {
-      closedAt: Date.now()
-    });
-  }
-); 
+export const closeBannerAtom = atom(null, (get, set) => {
+  set(bannerCloseAtom, {
+    closedAt: Date.now(),
+  });
+});


### PR DESCRIPTION
apps/wiki/components/BottomBanner.tsx
 - 始终挂载并同步高度：useLayoutEffect 以前在 isVisible 为 false 时直接 return，这会让第一次渲染或刷新后在水合阶段测不到高度，也不会更新 bannerHeightAtom。现在无论可见与否都先拿到 ref，再通过 updateHeight()
  把 --bottom-banner-height 设置成实际高度或 0；这样 MobileSidebar / MobileTOC 永远能拿到最新底边偏移，并且 Banner 在水合完成后不会因为“没测到高度”被认定为不该显示。
  - 关闭时同步归零：useEffect 保留着“如果 isVisible=false 就把 jotai 状态和 CSS 变量都归零”的动作，保证点击关闭或跨页面重用时 Banner 真的收回去；之所以还要另起一个 effect，是为了捕捉状态变成 false 的时机——不依
  赖 ResizeObserver，避免 Banner 滑出视野后高度还残留。