### PR TITLE
Feat/sequential navigation

### DIFF
--- a/apps/wiki/app/sitemap.ts
+++ b/apps/wiki/app/sitemap.ts
@@ -13,7 +13,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const seoConfig = getSEOConfig();
   const languageConfigs = getLanguageConfigs();
 
-  const urls: MetadataRoute.Sitemap = [];
+  const entries: Array<{ url: string; realPath?: string | null }> = [];
 
   // 添加首页 (该页会跳转，所以不添加)
   // urls.push({
@@ -25,7 +25,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // 为每种语言添加语言首页
   for (const langConfig of languageConfigs) {
-    urls.push({
+    entries.push({
       url: `${seoConfig.siteUrl}${langConfig.code}`,
     });
 
@@ -37,8 +37,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           subfolder,
         );
 
-        const { root: navigationItemRoot, map: navigationItemMap } =
-          await getDocsNavigationMap(langConfig.code, subfolder);
+        const { map: navigationItemMap } = await getDocsNavigationMap(
+          langConfig.code,
+          subfolder,
+        );
 
         for (const param of params) {
           if (param.slug && param.slug.length > 0) {
@@ -46,12 +48,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             const url = `${seoConfig.siteUrl}${param.language}/${path}`;
             const docItem = getDocItemByNavigationMap(navigationItemMap, path);
 
-            urls.push({
+            entries.push({
               url,
-              lastModified:
-                (docItem &&
-                  (await getFileLastModifiedTime(docItem.realPath))) ||
-                undefined,
+              realPath: docItem?.realPath || null,
             });
           }
         }
@@ -64,5 +63,60 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   }
 
-  return urls;
+  const parsedConcurrency = Number(process.env.SITEMAP_LASTMOD_CONCURRENCY);
+  const concurrency = Math.max(
+    1,
+    Number.isFinite(parsedConcurrency) && parsedConcurrency > 0
+      ? Math.floor(parsedConcurrency)
+      : 8,
+  );
+
+  return mapWithConcurrency(entries, concurrency, async (entry) => {
+    if (!entry.realPath) {
+      return { url: entry.url };
+    }
+
+    const lastModified = await getFileLastModifiedTime(entry.realPath);
+
+    if (!lastModified) {
+      return { url: entry.url };
+    }
+
+    return { url: entry.url, lastModified };
+  });
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  const effectiveLimit =
+    Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 1;
+  const workerCount = Math.min(effectiveLimit, items.length);
+  let currentIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = currentIndex;
+      currentIndex += 1;
+
+      if (index >= items.length) {
+        break;
+      }
+
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  if (workerCount === 0) {
+    return results;
+  }
+
+  const workers = Array.from({ length: workerCount }, () => worker());
+
+  await Promise.all(workers);
+
+  return results;
 }

--- a/apps/wiki/lib/i18n/translations/translations.json
+++ b/apps/wiki/lib/i18n/translations/translations.json
@@ -69,12 +69,40 @@
     "es": "Página anterior",
     "en": "Previous Page"
   },
+  "previousPageSibling": {
+    "zh-cn": "上一页（同级）",
+    "zh-hant": "上一頁（同級）",
+    "ja": "前のページ（同階層）",
+    "es": "Página anterior (mismo nivel)",
+    "en": "Previous (Same Level)"
+  },
+  "previousPageSequence": {
+    "zh-cn": "上一页（顺序）",
+    "zh-hant": "上一頁（順序）",
+    "ja": "前のページ（連続）",
+    "es": "Página anterior (secuencia)",
+    "en": "Previous (Sequential)"
+  },
   "nextPage": {
     "zh-cn": "下一页",
     "zh-hant": "下一頁",
     "ja": "次のページ",
     "es": "Página siguiente",
     "en": "Next Page"
+  },
+  "nextPageSibling": {
+    "zh-cn": "下一页（同级）",
+    "zh-hant": "下一頁（同級）",
+    "ja": "次のページ（同階層）",
+    "es": "Página siguiente (mismo nivel)",
+    "en": "Next (Same Level)"
+  },
+  "nextPageSequence": {
+    "zh-cn": "下一页（顺序）",
+    "zh-hant": "下一頁（順序）",
+    "ja": "次のページ（連続）",
+    "es": "Página siguiente (secuencia)",
+    "en": "Next (Sequential)"
   },
   "childPages": {
     "zh-cn": "子页面",

--- a/apps/wiki/service/directory-service-client.ts
+++ b/apps/wiki/service/directory-service-client.ts
@@ -30,3 +30,10 @@ export interface DocItemRedirectItem {
   displayPath: string;
   redirectTo: string;
 }
+
+export interface DocNavigationOrderEntry {
+  previous: string | null;
+  next: string | null;
+}
+
+export type DocNavigationOrderMap = Map<string, DocNavigationOrderEntry>;


### PR DESCRIPTION
## 目标

- **恢复/强化“阅读流畅性”这一全局原则**：无论信息架构如何，阅读不应被打断。
    
- **不破坏现有用例**：新增的是**并行通道**，不是替代路径；原有层级导航、子页面列表等全部保留。
    
- **可逆、可控**：任何跳转都能轻松回退，且跳转逻辑对用户是可感知、可预期的。
    

## 背景与取舍

- 既有 **“唯一子页面 → 自动跳转”** 已经偏离“严格层级一致性”，但提升了流畅性。
    
- 新增 **“上下页逻辑扩展”** 将该“例外”上升为系统规则：**从结构一致性转向体验一致性**。
    
- 代价：导航规则更复杂；收益：对“连续阅读”的主场景显著改善。
    

## 范围

- 适用对象：文档正文页的页尾导航区。

- 与“唯一子页面自动跳转” **并存**，但增加可感知的回退与提示。