### PR TITLE
add cas shortcode

### DIFF
--- a/apps/wiki/app/[language]/(documents)/[...slug]/utils.ts
+++ b/apps/wiki/app/[language]/(documents)/[...slug]/utils.ts
@@ -27,6 +27,7 @@ export function getNonSelfClosingElements() {
     'mtf-wiki',
     'telephone',
     'wiki',
+    'cas',
     'shields/qq',
     'shields/wechat',
     'shields/github-issue',

--- a/apps/wiki/components/shortcode/CAS.tsx
+++ b/apps/wiki/components/shortcode/CAS.tsx
@@ -1,0 +1,12 @@
+import type { ShortCodeCompProps } from './types';
+
+export default function CAS({ attrs }: ShortCodeCompProps) {
+  const id = attrs[0] || '';
+  const href = `https://commonchemistry.cas.org/detail?cas_rn=${id}`;
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {id}
+    </a>
+  );
+}

--- a/apps/wiki/components/shortcode/index.tsx
+++ b/apps/wiki/components/shortcode/index.tsx
@@ -12,6 +12,7 @@ const compsMap: ShortCodeCompRecord = {
   notice: dynamic(() => import('./Notice')),
   telephone: dynamic(() => import('./Telephone')),
   wiki: dynamic(() => import('./Wiki')),
+  cas: dynamic(() => import('./CAS')),
   ref: dynamic(() => import('./Ref')),
   local: dynamic(() => import('./Local')),
   hiddenphoto: dynamic(() => import('./hiddenPhoto')),


### PR DESCRIPTION
用于从CAS号生成一个指向commonchemistry.cas.org网站中对应化合物的超链接
