### PR TITLE
fix(wiki): improve Japanese localization

### DIFF
--- a/apps/wiki/app/[language]/(documents)/components/LayoutComponent.tsx
+++ b/apps/wiki/app/[language]/(documents)/components/LayoutComponent.tsx
@@ -49,7 +49,7 @@ export default function LayoutComponent({
         <main className="flex-1 min-w-0">
           <DocContent>{children}</DocContent>
           <div className="mt-8">
-            <SuggestionBox />
+            <SuggestionBox language={language} />
           </div>
         </main>
 

--- a/apps/wiki/app/[language]/converter/page.tsx
+++ b/apps/wiki/app/[language]/converter/page.tsx
@@ -13,7 +13,13 @@ export async function generateMetadata({
     title: '激素换算器 - MtF.wiki',
   };
 }
-export default function ConverterPage() {
+export default async function ConverterPage({
+  params,
+}: {
+  params: Promise<{ language: string }>;
+}) {
+  const { language } = await params;
+
   return (
     <div className="container mx-auto px-4 py-6 md:py-8">
       <div className="max-w-6xl mx-auto">
@@ -57,7 +63,7 @@ export default function ConverterPage() {
           </div>
         </footer>
         <div className="mt-8">
-          <SuggestionBox />
+          <SuggestionBox language={language} />
         </div>
       </div>
     </div>

--- a/apps/wiki/app/[language]/cup-calculator/page.tsx
+++ b/apps/wiki/app/[language]/cup-calculator/page.tsx
@@ -13,7 +13,13 @@ export async function generateMetadata({
   };
 }
 
-export default function CupCalculatorPage() {
+export default async function CupCalculatorPage({
+  params,
+}: {
+  params: Promise<{ language: string }>;
+}) {
+  const { language } = await params;
+
   return (
     <div className="container mx-auto px-4 py-6 md:py-8">
       <div className="max-w-4xl mx-auto">
@@ -95,7 +101,7 @@ export default function CupCalculatorPage() {
           </div>
         </footer>
         <div className="mt-8">
-          <SuggestionBox />
+          <SuggestionBox language={language} />
         </div>
       </div>
     </div>

--- a/apps/wiki/app/[language]/layout.tsx
+++ b/apps/wiki/app/[language]/layout.tsx
@@ -38,7 +38,10 @@ export default async function LanguageLayout({
   return (
     <div className="flex flex-col min-h-screen" lang={language}>
       {/* 浏览器升级横幅 - 只在不支持 :where() 的浏览器中显示 */}
-      <BrowserUpgradeBanner />
+      <BrowserUpgradeBanner
+        title={sT('browser-upgrade-title', language)}
+        description={sT('browser-upgrade-description', language)}
+      />
 
       {/* 顶部导航栏 */}
       <ObservedHeader className="lg:sticky lg:top-0 z-49 border-b bg-base-100/80 backdrop-blur-xl border-base-300/50 shadow-sm">

--- a/apps/wiki/components/BrowserUpgradeBanner.tsx
+++ b/apps/wiki/components/BrowserUpgradeBanner.tsx
@@ -1,15 +1,17 @@
-export default function BrowserUpgradeBanner() {
+export default function BrowserUpgradeBanner({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
   return (
     <div className="browser-upgrade-banner" suppressHydrationWarning>
       <div>
-        <strong>⚠️ 浏览器版本过旧 / Browser Version Too Old</strong>
+        <strong>{title}</strong>
       </div>
       <div style={{ marginTop: '4px' }}>
-        您的浏览器版本过旧，可能无法正常显示本网站。请使用更新版本的浏览器或操作系统。
-      </div>
-      <div style={{ marginTop: '2px', fontSize: '12px', opacity: '0.9' }}>
-        Your browser is outdated and may not display this website correctly.
-        Please use a newer version of your browser or operating system.
+        {description}
       </div>
     </div>
   );

--- a/apps/wiki/components/MobileSidebar.tsx
+++ b/apps/wiki/components/MobileSidebar.tsx
@@ -73,7 +73,7 @@ const MobileNavItem = ({
               type="button"
               onClick={() => setIsOpen(!isOpen)}
               className="p-2 ml-1 rounded-lg hover:bg-base-200 transition-colors"
-              aria-label={isOpen ? '收起' : '展开'}
+              aria-label={t(isOpen ? 'collapse' : 'expand', language)}
             >
               <ChevronDown
                 className={`w-4 h-4 transition-transform ${isOpen ? '' : '-rotate-90'}`}
@@ -262,7 +262,7 @@ export default function MobileSidebar({
                   type="button"
                   onClick={() => setIsOpen(false)}
                   className="p-2 rounded-lg hover:bg-base-300/50 transition-colors"
-                  aria-label="close"
+                  aria-label={t('close', language)}
                 >
                   <X className="w-5 h-5" />
                 </button>

--- a/apps/wiki/components/MobileTableOfContents.tsx
+++ b/apps/wiki/components/MobileTableOfContents.tsx
@@ -143,7 +143,7 @@ export default function MobileTableOfContents({
               }}
               role="button"
               tabIndex={0}
-              aria-label="关闭目录"
+              aria-label={t('closeToc', language)}
             />
 
             {/* 弹窗内容 */}
@@ -164,7 +164,7 @@ export default function MobileTableOfContents({
                   type="button"
                   onClick={() => setIsOpen(false)}
                   className="p-2 rounded-lg hover:bg-base-300/50 transition-colors"
-                  aria-label="close"
+                  aria-label={t('close', language)}
                 >
                   <X className="w-5 h-5" />
                 </button>

--- a/apps/wiki/components/SuggestionBox/index.tsx
+++ b/apps/wiki/components/SuggestionBox/index.tsx
@@ -1,28 +1,31 @@
 'use client';
+import { t } from '@/lib/i18n/client';
 import { useIsClient } from 'foxact/use-is-client';
 import { type FC, Suspense, lazy, memo } from 'react';
 import type { SuggestionBoxProps } from './types';
 
-const SuggestionBoxSkeleton = () => (
+const SuggestionBoxSkeleton = ({ language }: { language: string }) => (
   <div className="skeleton h-45 text-center flex items-center justify-center">
     <noscript>
-      <p>提问箱需要运行 JavaScript 以加载。</p>
-      <p>Suggestion Box requires JavaScript to load.</p>
+      <p>{t('suggestionBoxRequiresJavaScript', language)}</p>
     </noscript>
   </div>
 );
 
 const SuggestionBoxInner = lazy(() => import('./box'));
 
-const SuggestionBox_: FC<SuggestionBoxProps> = (props) => {
+const SuggestionBox_: FC<SuggestionBoxProps & { language: string }> = ({
+  language,
+  ...props
+}) => {
   const isClient = useIsClient();
 
   if (!isClient) {
-    return <SuggestionBoxSkeleton />;
+    return <SuggestionBoxSkeleton language={language} />;
   }
 
   return (
-    <Suspense fallback={<SuggestionBoxSkeleton />}>
+    <Suspense fallback={<SuggestionBoxSkeleton language={language} />}>
       <SuggestionBoxInner {...props} />
     </Suspense>
   );

--- a/apps/wiki/components/searchbox/SearchBox.tsx
+++ b/apps/wiki/components/searchbox/SearchBox.tsx
@@ -21,6 +21,8 @@ export default function SearchBox({
         'search-documents-try-different-keywords',
         language,
       )}
+      startSearchText={sT('search-documents-start', language)}
+      enterKeywordsText={sT('search-documents-enter-keywords', language)}
       compact={compact}
     />
   );

--- a/apps/wiki/components/searchbox/SearchBoxClient.tsx
+++ b/apps/wiki/components/searchbox/SearchBoxClient.tsx
@@ -12,6 +12,8 @@ interface SearchBoxProps {
   serverBuildIndex: boolean;
   notFoundText?: string;
   tryDifferentKeywordsText?: string;
+  startSearchText?: string;
+  enterKeywordsText?: string;
   compact?: boolean;
 }
 
@@ -88,6 +90,8 @@ export default function SearchBoxClient({
   serverBuildIndex,
   notFoundText,
   tryDifferentKeywordsText,
+  startSearchText,
+  enterKeywordsText,
   compact = false,
 }: SearchBoxProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -380,8 +384,8 @@ export default function SearchBoxClient({
               {!query && (
                 <div className="p-8 text-center text-base-content/60">
                   <Search className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                  <p className="text-lg mb-2">开始搜索</p>
-                  <p className="text-sm">输入关键词来搜索文档</p>
+                  <p className="text-lg mb-2">{startSearchText}</p>
+                  <p className="text-sm">{enterKeywordsText}</p>
                 </div>
               )}
             </div>

--- a/apps/wiki/lib/i18n/translations/server-translations.json
+++ b/apps/wiki/lib/i18n/translations/server-translations.json
@@ -20,31 +20,59 @@
     "es": "Intenta con diferentes palabras clave",
     "en": "Try different keywords"
   },
+  "search-documents-start": {
+    "zh-cn": "开始搜索",
+    "zh-hant": "開始搜尋",
+    "ja": "検索を開始",
+    "es": "Comenzar búsqueda",
+    "en": "Start searching"
+  },
+  "search-documents-enter-keywords": {
+    "zh-cn": "输入关键词来搜索文档",
+    "zh-hant": "輸入關鍵詞來搜尋文檔",
+    "ja": "キーワードを入力してドキュメントを検索します",
+    "es": "Introduce palabras clave para buscar documentos",
+    "en": "Enter keywords to search documents"
+  },
+  "browser-upgrade-title": {
+    "zh-cn": "⚠️ 浏览器版本过旧",
+    "zh-hant": "⚠️ 瀏覽器版本過舊",
+    "ja": "⚠️ ブラウザが古い可能性があります",
+    "es": "⚠️ Navegador obsoleto",
+    "en": "⚠️ Browser Version Too Old"
+  },
+  "browser-upgrade-description": {
+    "zh-cn": "您的浏览器版本过旧，可能无法正常显示本网站。请使用更新版本的浏览器或操作系统。",
+    "zh-hant": "您的瀏覽器版本過舊，可能無法正常顯示本網站。請使用更新版本的瀏覽器或作業系統。",
+    "ja": "お使いのブラウザは古いため、このサイトが正しく表示されない可能性があります。新しいブラウザまたは OS をご利用ください。",
+    "es": "Tu navegador está obsoleto y puede que no muestre este sitio correctamente. Usa una versión más reciente del navegador o del sistema operativo.",
+    "en": "Your browser is outdated and may not display this website correctly. Please use a newer browser or operating system."
+  },
   "banner-text-disclaimer": {
     "zh-cn": "MtF.wiki 的内容仅供参考，可能存在过时或不准确的信息，请谨慎甄别。",
     "zh-hant": "MtF.wiki 的內容僅供參考，可能存在過時或不準確的信息，請謹慎甄別。",
-    "ja": "MtF.wiki の内容は参考になりますが、過去の情報や不正確な情報が含まれている可能性があります。ご注意ください。",
+    "ja": "MtF.wiki の内容は参考情報であり、古い情報や不正確な情報が含まれる可能性があります。ご自身で慎重にご確認ください。",
     "es": "El contenido de MtF.wiki es solo para referencia y puede contener información obsoleta o incorrecta. Por favor, ten cuidado.",
     "en": "The content of MtF.wiki is for reference only and may contain outdated or inaccurate information. Please be cautious."
   },
   "banner-text-disclaimer-preview": {
     "zh-cn": "MtF.wiki 的内容仅供参考，可能存在过时或不准确的信息，请谨慎甄别。（您当前访问的是技术测试版本站点，仅供技术测试相关需求使用）",
     "zh-hant": "MtF.wiki 的內容僅供參考，可能存在過時或不準確的信息，請謹慎甄別。（您當前訪問的是技術測試版本站點，僅供技術測試相關需求使用）",
-    "ja": "MtF.wiki の内容は参考になりますが、過去の情報や不正確な情報が含まれている可能性があります。ご注意ください。（あなたは現在技術テストバージョンのサイトにアクセスしています。技術テストのみに使用してください。）",
+    "ja": "MtF.wiki の内容は参考情報であり、古い情報や不正確な情報が含まれる可能性があります。ご自身で慎重にご確認ください。（現在、技術テスト版のサイトを表示しています。技術テスト目的でのみご利用ください。）",
     "es": "El contenido de MtF.wiki es solo para referencia y puede contener información obsoleta o incorrecta. Por favor, ten cuidado. (Actualmente estás visitando un sitio web de versión de prueba técnica. Solo para uso técnico.)",
     "en": "The content of MtF.wiki is for reference only and may contain outdated or inaccurate information. Please be cautious. (You are currently visiting a technical test version site. Only for technical test.)"
   },
   "banner-button-text-disclaimer": {
     "zh-cn": "免责声明",
     "zh-hant": "免責聲明",
-    "ja": "免責聲明",
+    "ja": "免責事項",
     "es": "Aviso de免责",
     "en": "Disclaimer"
   },
   "banner-button-link-disclaimer": {
     "zh-cn": "/zh-cn/about/disclaimer",
     "zh-hant": "/en/about/disclaimer",
-    "ja": "/en/about/disclaimer",
+    "ja": "/ja/about/disclaimer",
     "es": "/en/about/disclaimer",
     "en": "/en/about/disclaimer"
   },
@@ -58,7 +86,7 @@
   "last-modified-time": {
     "zh-cn": "最近更新于",
     "zh-hant": "最近更新於",
-    "ja": "最近更新於",
+    "ja": "最終更新日",
     "es": "Última modificación ",
     "en": "Last Modified "
   },
@@ -79,7 +107,7 @@
   "home-page-description": {
     "zh-cn": "欢迎来到 MtF.wiki．我们试图整理汇总女性倾向跨性别的相关资料，为大家提供更好的帮助~",
     "zh-hant": "歡迎來到 MtF.wiki．我們試圖整理匯總女性傾向跨性別的相關資料，為大家提供更好的幫助~",
-    "ja": "MtF.wiki へようこそ。 吾輩は、女性的なトランスジェンダーに関する情報を整理して要約し、より良い支援を提供するよう努めています〜",
+    "ja": "MtF.wiki へようこそ。吾輩らは、トランスフェミニンの方に関する情報を整理し、より良い支援につなげることを目指している。",
     "es": "Bienvenida a MtF.wiki. Tratamos de organizar la información relevante de transfeminidad para daros mejor ayuda ^_^",
     "en": "Welcome to the MtF.wiki. We are trying to organize the relevant information of transfeminine to provide you with better help ^_^"
   },
@@ -107,14 +135,14 @@
   "content-source": {
     "zh-cn": "文档内容源码",
     "zh-hant": "文檔內容源碼",
-    "ja": "ドキュメントコンテンツソースコード",
+    "ja": "ドキュメント本文のソースコード",
     "es": "Código fuente del contenido del documento",
     "en": "Document Content Source Code"
   },
   "website-source": {
     "zh-cn": "网站框架源码",
     "zh-hant": "網站框架源碼",
-    "ja": "ウェブサイトフレームワークソースコード",
+    "ja": "ウェブサイト基盤のソースコード",
     "es": "Código fuente del sitio web",
     "en": "Website Framework Source Code"
   },
@@ -177,7 +205,7 @@
   "all-rights-reserved": {
     "zh-cn": "All rights reserved. Maintained by",
     "zh-hant": "All rights reserved. Maintained by",
-    "ja": "All rights reserved. Maintained by",
+    "ja": "All rights reserved. 運営：",
     "es": "Todos los derechos reservados. Mantenido por",
     "en": "All rights reserved. Maintained by"
   },
@@ -219,14 +247,14 @@
   "header-navigation": {
     "zh-cn": "板块",
     "zh-hant": "板塊",
-    "ja": "板塊",
+    "ja": "ナビゲーション",
     "es": "División",
     "en": "Division"
   },
   "redirect-client-text": {
     "zh-cn": "如果您的浏览器没有自动跳转，请点击此处",
     "zh-hant": "如果您的瀏覽器沒有自動跳轉，請點擊此處",
-    "ja": "ブラウザーが自動的にリダイレクトされない場合は、ここをクリックしてください",
+    "ja": "ブラウザが自動的にリダイレクトしない場合は、ここをクリックしてください",
     "es": "Si el navegador no redirige automáticamente, haga clic aquí",
     "en": "If the browser does not redirect automatically, click here"
   }

--- a/apps/wiki/lib/i18n/translations/server-translations.json
+++ b/apps/wiki/lib/i18n/translations/server-translations.json
@@ -107,7 +107,7 @@
   "home-page-description": {
     "zh-cn": "欢迎来到 MtF.wiki．我们试图整理汇总女性倾向跨性别的相关资料，为大家提供更好的帮助~",
     "zh-hant": "歡迎來到 MtF.wiki．我們試圖整理匯總女性傾向跨性別的相關資料，為大家提供更好的幫助~",
-    "ja": "MtF.wiki へようこそ。吾輩らは、トランスフェミニンの方に関する情報を整理し、より良い支援につなげることを目指している。",
+    "ja": "MtF.wikiへようこそ。吾輩らは、トランス女性やトランスフェミニンの方に関する情報を整理し、より良い支援につなげることを目指している。",
     "es": "Bienvenida a MtF.wiki. Tratamos de organizar la información relevante de transfeminidad para daros mejor ayuda ^_^",
     "en": "Welcome to the MtF.wiki. We are trying to organize the relevant information of transfeminine to provide you with better help ^_^"
   },

--- a/apps/wiki/lib/i18n/translations/translations.json
+++ b/apps/wiki/lib/i18n/translations/translations.json
@@ -9,7 +9,7 @@
   "about": {
     "zh-cn": "关于",
     "zh-hant": "關於",
-    "ja": "について",
+    "ja": "サイト概要",
     "es": "Acerca de",
     "en": "About"
   },
@@ -159,5 +159,40 @@
     "ja": "現在のフォント",
     "es": "Fuente actual",
     "en": "Current Font"
+  },
+  "close": {
+    "zh-cn": "关闭",
+    "zh-hant": "關閉",
+    "ja": "閉じる",
+    "es": "Cerrar",
+    "en": "Close"
+  },
+  "expand": {
+    "zh-cn": "展开",
+    "zh-hant": "展開",
+    "ja": "展開する",
+    "es": "Expandir",
+    "en": "Expand"
+  },
+  "collapse": {
+    "zh-cn": "收起",
+    "zh-hant": "收合",
+    "ja": "折りたたむ",
+    "es": "Contraer",
+    "en": "Collapse"
+  },
+  "closeToc": {
+    "zh-cn": "关闭目录",
+    "zh-hant": "關閉目錄",
+    "ja": "目次を閉じる",
+    "es": "Cerrar índice",
+    "en": "Close table of contents"
+  },
+  "suggestionBoxRequiresJavaScript": {
+    "zh-cn": "提问箱需要运行 JavaScript 以加载。",
+    "zh-hant": "提問箱需要執行 JavaScript 才能載入。",
+    "ja": "質問箱の読み込みには JavaScript が必要です。",
+    "es": "El buzón de sugerencias requiere JavaScript para cargarse.",
+    "en": "Suggestion Box requires JavaScript to load."
   }
 }


### PR DESCRIPTION
## Summary
- improve Japanese navigation and shared UI copy, including the about label, disclaimer text, browser upgrade banner, and footer labels
- localize remaining shared Japanese strings in search, suggestion-box fallback, and mobile accessibility labels
- preserve the distinctive homepage voice by updating the intro copy to use `吾輩ら`

## Notes
- JSON translation files were validated locally
- converter and cup-calculator pages still contain larger Chinese-only UI sections outside the shared `/ja` localization scope of this change

## Related PR
https://github.com/project-trans/MtF-wiki/pull/1723