### PR TITLE
feat(wiki): add searchable multilingual terminology glossary

### DIFF
--- a/apps/wiki/app/[language]/(documents)/[...slug]/page.tsx
+++ b/apps/wiki/app/[language]/(documents)/[...slug]/page.tsx
@@ -15,6 +15,7 @@ import { LanguageAlternate } from '@/components/LanguageAlternate';
 import { LocalImage } from '@/components/LocalImage';
 import { MarkdownCopyInterceptor } from '@/components/MarkdownCopyInterceptor';
 import { Link } from '@/components/progress';
+import SearchableTerminologyTable from '@/components/SearchableTerminologyTable';
 import { ShortCodeComp } from '@/components/shortcode';
 import { cache } from '@/lib/cache';
 import { t } from '@/lib/i18n/client';
@@ -33,12 +34,26 @@ import SingleChildRedirect from '../components/SingleChildRedirect';
 import remarkCsvToTable from './remarkCsvToTable';
 import remarkHtmlContent from './remarkHtmlContent';
 import remarkQrCode, { remarkHugoShortcode } from './remarkHugoShortcode';
+import remarkTerminologyGlossary from './remarkTerminologyGlossary';
 import type { Frontmatter } from './types';
 import {
   getAvailableLanguages,
   getContentDir,
   getContentGitRootDir,
 } from './utils';
+
+const loadTerminologyData = cache(async (): Promise<string> => {
+  try {
+    const tsvPath = path.join(
+      getContentGitRootDir(),
+      'data',
+      'terminology.tsv',
+    );
+    return await fs.readFile(tsvPath, 'utf-8');
+  } catch {
+    return '';
+  }
+});
 
 interface DocParams {
   language: string;
@@ -322,11 +337,18 @@ export default async function DocPage({
     });
   }
 
+  const terminologyData = await loadTerminologyData();
+
+  function remarkTerminologyGlossaryPlugin() {
+    return remarkTerminologyGlossary({ language, data: terminologyData });
+  }
+
   const mdxRawContent: string = strippedSource;
   const remarkPlugins = [
     remarkHeadingIdPlugin,
     remarkCsvToTablePlugin,
     remarkHugoShortcodePlugin,
+    remarkTerminologyGlossaryPlugin,
     remarkGfm,
     remarkMath,
     remarkHtmlContent,
@@ -352,6 +374,7 @@ export default async function DocPage({
 
   // 定义组件映射
   const components: MDXComponents = {
+    SearchableTerminologyTable,
     ShortCodeComp: (props) => (
       <ShortCodeComp
         {...props}

--- a/apps/wiki/app/[language]/(documents)/[...slug]/remarkTerminologyGlossary.ts
+++ b/apps/wiki/app/[language]/(documents)/[...slug]/remarkTerminologyGlossary.ts
@@ -1,0 +1,51 @@
+import type { Node, Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+interface MdxJsxAttribute {
+  type: 'mdxJsxAttribute';
+  name: string;
+  value: string | null;
+}
+
+interface MdxJsxFlowElement extends Node {
+  type: 'mdxJsxFlowElement';
+  name: string;
+  attributes: MdxJsxAttribute[];
+  children: Node[];
+}
+
+interface Options {
+  language: string;
+  data: string;
+}
+
+/**
+ * Remark plugin: replaces {{< terminology-glossary >}} shortcode nodes
+ * (already converted to ShortCodeComp by remarkHugoShortcode) with a
+ * SearchableTerminologyTable MDX element carrying pre-loaded TSV data.
+ */
+export default function remarkTerminologyGlossary({ language, data }: Options) {
+  return (tree: Root) => {
+    visit(tree, 'mdxJsxFlowElement', (node, index, parent) => {
+      const el = node as unknown as MdxJsxFlowElement;
+      if (el.name !== 'ShortCodeComp') return;
+
+      const compNameAttr = el.attributes?.find((a) => a.name === 'compName');
+      if (compNameAttr?.value !== 'terminology-glossary') return;
+
+      const replacement: MdxJsxFlowElement = {
+        type: 'mdxJsxFlowElement',
+        name: 'SearchableTerminologyTable',
+        attributes: [
+          { type: 'mdxJsxAttribute', name: 'data', value: data },
+          { type: 'mdxJsxAttribute', name: 'lang', value: language },
+        ],
+        children: [],
+      };
+
+      if (parent && typeof index === 'number' && 'children' in parent) {
+        (parent.children as unknown[])[index] = replacement;
+      }
+    });
+  };
+}

--- a/apps/wiki/app/[language]/(documents)/[...slug]/utils.ts
+++ b/apps/wiki/app/[language]/(documents)/[...slug]/utils.ts
@@ -51,5 +51,6 @@ export function getNonSelfClosingElements() {
     'meme/onimai-ja',
     'project-trans',
     'github/contributors',
+    'terminology-glossary',
   ];
 }

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -434,10 +434,10 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                         {isOpen && canExpand && (
                           <tr
                             key={`${entry.id}-detail`}
-                            className="bg-base-100"
+                            className="bg-base-200"
                           >
                             <td colSpan={colCount} className="px-4 py-3">
-                              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-xs">
                                 {lang === 'zh-cn' && entry.avoid && (
                                   <>
                                     <dt className="font-semibold text-error/80">
@@ -491,7 +491,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                             href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            className="link text-primary/65 text-xs font-mono hover:text-primary"
+                                            className="link font-mono text-base-content/70 hover:text-base-content"
                                             onClick={(ev) =>
                                               ev.stopPropagation()
                                             }
@@ -503,7 +503,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                               href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${wikiLang}wiki/${entry.wikidata}`}
                                               target="_blank"
                                               rel="noopener noreferrer"
-                                              className="link text-primary/65 text-xs hover:text-primary"
+                                              className="link text-base-content/70 hover:text-base-content"
                                               onClick={(ev) =>
                                                 ev.stopPropagation()
                                               }
@@ -515,7 +515,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                             href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/enwiki/${entry.wikidata}`}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            className="link text-primary/65 text-xs hover:text-primary"
+                                            className="link text-base-content/70 hover:text-base-content"
                                             onClick={(ev) =>
                                               ev.stopPropagation()
                                             }

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -468,33 +468,66 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                     </dd>
                                   </>
                                 )}
-                                {entry.wikidata && (
-                                  <>
-                                    <dt className="font-semibold text-base-content/60">
-                                      Wikidata
-                                    </dt>
-                                    <dd className="flex items-center gap-2 flex-wrap">
-                                      <a
-                                        href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="link link-primary text-xs font-mono"
-                                        onClick={(ev) => ev.stopPropagation()}
-                                      >
-                                        {entry.wikidata}
-                                      </a>
-                                      <a
-                                        href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${({ 'zh-cn': 'zh', 'zh-hant': 'zh', ja: 'ja', en: 'en', es: 'es' } as Record<string, string>)[lang] ?? 'en'}wiki/${entry.wikidata}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="link link-primary text-xs"
-                                        onClick={(ev) => ev.stopPropagation()}
-                                      >
-                                        Wikipedia ↗
-                                      </a>
-                                    </dd>
-                                  </>
-                                )}
+                                {entry.wikidata &&
+                                  (() => {
+                                    const wikiLang =
+                                      (
+                                        {
+                                          'zh-cn': 'zh',
+                                          'zh-hant': 'zh',
+                                          ja: 'ja',
+                                          en: 'en',
+                                          es: 'es',
+                                        } as Record<string, string>
+                                      )[lang] ?? 'en';
+                                    const isEnglish = wikiLang === 'en';
+                                    return (
+                                      <>
+                                        <dt className="font-semibold text-base-content/60">
+                                          Wikidata
+                                        </dt>
+                                        <dd className="flex items-center gap-2 flex-wrap">
+                                          <a
+                                            href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="link link-primary text-xs font-mono"
+                                            onClick={(ev) =>
+                                              ev.stopPropagation()
+                                            }
+                                          >
+                                            {entry.wikidata}
+                                          </a>
+                                          {!isEnglish && (
+                                            <a
+                                              href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${wikiLang}wiki/${entry.wikidata}`}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="link link-primary text-xs"
+                                              onClick={(ev) =>
+                                                ev.stopPropagation()
+                                              }
+                                            >
+                                              Wikipedia ↗
+                                            </a>
+                                          )}
+                                          <a
+                                            href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/enwiki/${entry.wikidata}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="link link-primary text-xs"
+                                            onClick={(ev) =>
+                                              ev.stopPropagation()
+                                            }
+                                          >
+                                            {isEnglish
+                                              ? 'Wikipedia ↗'
+                                              : 'Wikipedia (EN) ↗'}
+                                          </a>
+                                        </dd>
+                                      </>
+                                    );
+                                  })()}
                               </dl>
                             </td>
                           </tr>

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -491,7 +491,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                             href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            className="link link-primary text-xs font-mono"
+                                            className="link text-primary/65 text-xs font-mono hover:text-primary"
                                             onClick={(ev) =>
                                               ev.stopPropagation()
                                             }
@@ -503,7 +503,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                               href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${wikiLang}wiki/${entry.wikidata}`}
                                               target="_blank"
                                               rel="noopener noreferrer"
-                                              className="link link-primary text-xs"
+                                              className="link text-primary/65 text-xs hover:text-primary"
                                               onClick={(ev) =>
                                                 ev.stopPropagation()
                                               }
@@ -515,7 +515,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                             href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/enwiki/${entry.wikidata}`}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            className="link link-primary text-xs"
+                                            className="link text-primary/65 text-xs hover:text-primary"
                                             onClick={(ev) =>
                                               ev.stopPropagation()
                                             }

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -408,14 +408,25 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                             );
                           })}
                           <td className="text-right align-top whitespace-nowrap">
-                            {canExpand && (
-                              <span
-                                className={`inline-block transition-transform duration-150 text-base-content/40 ${isOpen ? 'rotate-90' : ''}`}
-                                aria-hidden="true"
-                              >
-                                ›
-                              </span>
-                            )}
+                            <span className="inline-flex items-center gap-1">
+                              {entry.wikidata && (
+                                <span
+                                  className="text-[10px] text-base-content/30 font-mono leading-none"
+                                  title={`Wikidata: ${entry.wikidata}`}
+                                  aria-hidden="true"
+                                >
+                                  W
+                                </span>
+                              )}
+                              {canExpand && (
+                                <span
+                                  className={`inline-block transition-transform duration-150 text-base-content/40 ${isOpen ? 'rotate-90' : ''}`}
+                                  aria-hidden="true"
+                                >
+                                  ›
+                                </span>
+                              )}
+                            </span>
                           </td>
                         </tr>
 

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -14,7 +14,11 @@ export interface TermEntry {
   en: string;
   es: string;
   source: string;
-  aliases: string;
+  'aliases-zh-cn': string;
+  'aliases-zh-hant': string;
+  'aliases-ja': string;
+  'aliases-en': string;
+  'aliases-es': string;
   avoid: string;
   disputed: string;
   notes: string;
@@ -191,7 +195,11 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
         e.en,
         e.es,
         e.abbr,
-        e.aliases,
+        e['aliases-zh-cn'],
+        e['aliases-zh-hant'],
+        e['aliases-ja'],
+        e['aliases-en'],
+        e['aliases-es'],
         e.notes,
       ].some((v) => v?.toLowerCase().includes(q)),
     );
@@ -295,10 +303,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
           <thead>
             <tr className="bg-base-200">
               {langOrder.map((l) => (
-                <th
-                  key={l}
-                  className={`whitespace-nowrap ${l === (lang as LangCode) ? 'font-bold text-primary' : ''}`}
-                >
+                <th key={l} className="whitespace-nowrap">
                   {LANG_LABELS[l]}
                 </th>
               ))}
@@ -332,12 +337,6 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                   {catEntries.map((entry) => {
                     const isOpen = expanded.has(entry.id);
                     const canExpand = hasExpandContent(entry, lang);
-                    const aliasList = entry.aliases
-                      ? entry.aliases
-                          .split('/')
-                          .map((a) => a.trim())
-                          .filter(Boolean)
-                      : [];
 
                     return (
                       <>
@@ -382,19 +381,29 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                   </span>
                                 )}
 
-                                {/* Aliases — zh-cn column only, as chips */}
-                                {l === 'zh-cn' && aliasList.length > 0 && (
-                                  <div className="mt-1 flex flex-wrap gap-0.5">
-                                    {aliasList.map((alias) => (
-                                      <span
-                                        key={alias}
-                                        className="badge badge-xs badge-ghost text-[10px] text-base-content/40"
-                                      >
-                                        {highlight(alias, query)}
-                                      </span>
-                                    ))}
-                                  </div>
-                                )}
+                                {/* Aliases — per language, as small chips */}
+                                {(() => {
+                                  const key = `aliases-${l}` as keyof TermEntry;
+                                  const raw = entry[key] as string;
+                                  const list = raw
+                                    ? raw
+                                        .split('/')
+                                        .map((a) => a.trim())
+                                        .filter(Boolean)
+                                    : [];
+                                  return list.length > 0 ? (
+                                    <div className="mt-1 flex flex-wrap gap-0.5">
+                                      {list.map((alias) => (
+                                        <span
+                                          key={alias}
+                                          className="badge badge-xs badge-ghost text-[10px] text-base-content/40"
+                                        >
+                                          {highlight(alias, query)}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  ) : null;
+                                })()}
                               </td>
                             );
                           })}
@@ -451,11 +460,11 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                 {entry.wikidata && (
                                   <>
                                     <dt className="font-semibold text-base-content/60">
-                                      Wikidata
+                                      Wikipedia
                                     </dt>
                                     <dd>
                                       <a
-                                        href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
+                                        href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${({ 'zh-cn': 'zh', 'zh-hant': 'zh', ja: 'ja', en: 'en', es: 'es' } as Record<string, string>)[lang] ?? 'en'}wiki/${entry.wikidata}`}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="link link-primary text-xs font-mono"

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -33,8 +33,8 @@ const LANG_ORDER = ['zh-cn', 'zh-hant', 'ja', 'en', 'es'] as const;
 type LangCode = (typeof LANG_ORDER)[number];
 
 const LANG_LABELS: Record<LangCode, string> = {
-  'zh-cn': '中文（简）',
-  'zh-hant': '中文（繁）',
+  'zh-cn': '简体中文',
+  'zh-hant': '繁体中文',
   ja: '日本語',
   en: 'English',
   es: 'Español',

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -206,7 +206,7 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
     const groups: { category: string; entries: TermEntry[] }[] = [];
     for (const entry of sorted) {
       const last = groups[groups.length - 1];
-      if (last?.category === entry.category) last.entries.push(entry);
+      if (last && last.category === entry.category) last.entries.push(entry);
       else groups.push({ category: entry.category, entries: [entry] });
     }
     return groups;

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { t } from '@/lib/i18n/client';
 
 export interface TermEntry {
   id: string;
   wikidata: string;
+  category: string;
+  abbr: string;
   'zh-cn': string;
   'zh-hant': string;
   ja: string;
@@ -34,6 +36,92 @@ const LANG_LABELS: Record<LangCode, string> = {
   es: 'Español',
 };
 
+const CATEGORY_ORDER = [
+  'identity',
+  'hrt',
+  'surgery',
+  'voice',
+  'hair-removal',
+  'medical',
+  'legal',
+  'social',
+  'lab',
+  'misc',
+] as const;
+
+const CATEGORY_LABELS: Record<string, Record<string, string>> = {
+  identity: {
+    'zh-cn': '身份认同',
+    'zh-hant': '身份認同',
+    ja: 'アイデンティティ',
+    en: 'Identity',
+    es: 'Identidad',
+  },
+  hrt: {
+    'zh-cn': '激素治疗',
+    'zh-hant': '激素治療',
+    ja: 'ホルモン療法',
+    en: 'Hormone Therapy',
+    es: 'Terapia Hormonal',
+  },
+  surgery: {
+    'zh-cn': '手术',
+    'zh-hant': '手術',
+    ja: '手術',
+    en: 'Surgery',
+    es: 'Cirugía',
+  },
+  voice: {
+    'zh-cn': '嗓音',
+    'zh-hant': '嗓音',
+    ja: '音声',
+    en: 'Voice',
+    es: 'Voz',
+  },
+  'hair-removal': {
+    'zh-cn': '脱毛',
+    'zh-hant': '脫毛',
+    ja: '脱毛',
+    en: 'Hair Removal',
+    es: 'Depilación',
+  },
+  medical: {
+    'zh-cn': '医疗体系',
+    'zh-hant': '醫療體系',
+    ja: '医療体制',
+    en: 'Medical',
+    es: 'Sistema Médico',
+  },
+  legal: {
+    'zh-cn': '法律与证件',
+    'zh-hant': '法律與證件',
+    ja: '法律・証明書',
+    en: 'Legal',
+    es: 'Legal',
+  },
+  social: {
+    'zh-cn': '社群与社会',
+    'zh-hant': '社群與社會',
+    ja: '社会',
+    en: 'Social',
+    es: 'Social',
+  },
+  lab: {
+    'zh-cn': '检验指标',
+    'zh-hant': '檢驗指標',
+    ja: '検査値',
+    en: 'Lab Values',
+    es: 'Valores Lab',
+  },
+  misc: {
+    'zh-cn': '其他',
+    'zh-hant': '其他',
+    ja: 'その他',
+    en: 'Other',
+    es: 'Otros',
+  },
+};
+
 function parseTsv(raw: string): TermEntry[] {
   const lines = raw.trim().split('\n');
   if (lines.length < 2) return [];
@@ -53,7 +141,7 @@ function highlight(text: string, query: string): React.ReactNode {
   return (
     <>
       {text.slice(0, idx)}
-      <mark className="bg-warning/40 text-inherit rounded-sm px-0.5">
+      <mark className="bg-yellow-200 dark:bg-yellow-700/70 text-inherit not-italic rounded-sm px-px">
         {text.slice(idx, idx + query.length)}
       </mark>
       {text.slice(idx + query.length)}
@@ -61,17 +149,36 @@ function highlight(text: string, query: string): React.ReactNode {
   );
 }
 
+function hasExpandContent(e: TermEntry, lang: string): boolean {
+  return (
+    (lang === 'zh-cn' && !!(e.avoid || e.disputed || e.notes)) || !!e.wikidata
+  );
+}
+
+function getCategoryLabel(category: string, lang: string): string {
+  return (
+    CATEGORY_LABELS[category]?.[lang] ??
+    CATEGORY_LABELS[category]?.en ??
+    category
+  );
+}
+
 export default function SearchableTerminologyTable({ data, lang }: Props) {
   const [query, setQuery] = useState('');
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [hiddenCols, setHiddenCols] = useState<Set<LangCode>>(new Set());
+  const [colMenuOpen, setColMenuOpen] = useState(false);
+  const colMenuRef = useRef<HTMLDivElement>(null);
 
   const entries = useMemo(() => parseTsv(data), [data]);
 
   const langOrder = useMemo<LangCode[]>(() => {
     const cur = lang as LangCode;
-    if (!LANG_ORDER.includes(cur)) return [...LANG_ORDER];
-    return [cur, ...LANG_ORDER.filter((l) => l !== cur)];
-  }, [lang]);
+    const base = LANG_ORDER.includes(cur)
+      ? [cur, ...LANG_ORDER.filter((l) => l !== cur)]
+      : [...LANG_ORDER];
+    return base.filter((l) => !hiddenCols.has(l));
+  }, [lang, hiddenCols]);
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
@@ -83,44 +190,106 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
         e.ja,
         e.en,
         e.es,
-        e.source,
+        e.abbr,
         e.aliases,
         e.notes,
       ].some((v) => v?.toLowerCase().includes(q)),
     );
   }, [entries, query]);
 
-  const toggleExpand = (id: string) => {
+  const grouped = useMemo(() => {
+    const sorted = [...filtered].sort((a, b) => {
+      const ai = (CATEGORY_ORDER as readonly string[]).indexOf(a.category);
+      const bi = (CATEGORY_ORDER as readonly string[]).indexOf(b.category);
+      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    });
+    const groups: { category: string; entries: TermEntry[] }[] = [];
+    for (const entry of sorted) {
+      const last = groups[groups.length - 1];
+      if (last?.category === entry.category) last.entries.push(entry);
+      else groups.push({ category: entry.category, entries: [entry] });
+    }
+    return groups;
+  }, [filtered]);
+
+  const toggleExpand = (id: string) =>
     setExpanded((prev) => {
       const next = new Set(prev);
       next.has(id) ? next.delete(id) : next.add(id);
       return next;
     });
-  };
 
-  const hasDetails = (e: TermEntry) =>
-    e.source || e.aliases || e.avoid || e.disputed || e.notes;
+  const toggleCol = (l: LangCode) =>
+    setHiddenCols((prev) => {
+      const next = new Set(prev);
+      next.has(l) ? next.delete(l) : next.add(l);
+      return next;
+    });
 
   const countText = t('terminology-count', lang)
     .replace('{shown}', String(filtered.length))
     .replace('{total}', String(entries.length));
 
+  const colCount = langOrder.length + 1;
+
   return (
     <div className="my-6 not-prose">
-      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap gap-2 mb-3 items-center">
         <input
           type="search"
-          className="input input-bordered input-sm flex-1 max-w-sm"
+          className="input input-bordered input-sm flex-1 min-w-40 max-w-sm"
           placeholder={t('terminology-search', lang)}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           aria-label={t('terminology-search', lang)}
         />
-        <span className="text-sm text-base-content/60 self-center">
+        <span className="text-sm text-base-content/60 shrink-0">
           {countText}
         </span>
+
+        {/* Column visibility toggle */}
+        <div className="relative shrink-0" ref={colMenuRef}>
+          <button
+            type="button"
+            className="btn btn-sm btn-ghost gap-1"
+            onClick={() => setColMenuOpen((v) => !v)}
+            aria-expanded={colMenuOpen}
+          >
+            <svg
+              className="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M3 6h18M3 12h18M3 18h18" />
+            </svg>
+            {t('terminology-columns', lang)}
+          </button>
+          {colMenuOpen && (
+            <div className="absolute right-0 z-50 mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg p-2 flex flex-col gap-1 min-w-36">
+              {LANG_ORDER.map((l) => (
+                <label
+                  key={l}
+                  className="flex items-center gap-2 cursor-pointer px-2 py-1 rounded hover:bg-base-200 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    className="checkbox checkbox-xs"
+                    checked={!hiddenCols.has(l)}
+                    onChange={() => toggleCol(l)}
+                  />
+                  {LANG_LABELS[l]}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
+      {/* Table */}
       <div className="overflow-x-auto rounded-lg border border-base-300">
         <table className="table table-xs table-pin-rows w-full">
           <thead>
@@ -128,143 +297,184 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
               {langOrder.map((l) => (
                 <th
                   key={l}
-                  className={l === lang ? 'font-bold text-primary' : ''}
+                  className={`whitespace-nowrap ${l === (lang as LangCode) ? 'font-bold text-primary' : ''}`}
                 >
                   {LANG_LABELS[l]}
                 </th>
               ))}
-              <th className="w-6" aria-label="details" />
+              <th className="w-5" aria-label="expand" />
             </tr>
           </thead>
           <tbody>
-            {filtered.length === 0 ? (
+            {grouped.length === 0 ? (
               <tr>
                 <td
-                  colSpan={langOrder.length + 1}
+                  colSpan={colCount}
                   className="text-center text-base-content/50 py-8"
                 >
                   {t('terminology-no-results', lang)}
                 </td>
               </tr>
             ) : (
-              filtered.map((entry) => {
-                const isOpen = expanded.has(entry.id);
-                return (
-                  <>
-                    <tr
-                      key={entry.id}
-                      className="hover:bg-base-200/50 cursor-pointer"
-                      onClick={() =>
-                        hasDetails(entry) && toggleExpand(entry.id)
-                      }
-                      aria-expanded={hasDetails(entry) ? isOpen : undefined}
+              grouped.map(({ category, entries: catEntries }) => (
+                <>
+                  {/* Category header */}
+                  <tr key={`cat-${category}`} className="bg-base-200/80">
+                    <td
+                      colSpan={colCount}
+                      className="py-1 px-3 text-xs font-semibold uppercase tracking-wide text-base-content/50 whitespace-nowrap"
                     >
-                      {langOrder.map((l) => (
-                        <td
-                          key={l}
+                      {getCategoryLabel(category, lang)}
+                    </td>
+                  </tr>
+
+                  {/* Term rows */}
+                  {catEntries.map((entry) => {
+                    const isOpen = expanded.has(entry.id);
+                    const canExpand = hasExpandContent(entry, lang);
+                    const aliasList = entry.aliases
+                      ? entry.aliases
+                          .split('/')
+                          .map((a) => a.trim())
+                          .filter(Boolean)
+                      : [];
+
+                    return (
+                      <>
+                        <tr
+                          key={entry.id}
                           className={
-                            l === lang ? 'font-medium' : 'text-base-content/70'
+                            canExpand
+                              ? 'hover:bg-base-200/50 cursor-pointer'
+                              : ''
                           }
+                          onClick={() => canExpand && toggleExpand(entry.id)}
+                          aria-expanded={canExpand ? isOpen : undefined}
                         >
-                          {highlight(entry[l], query) || (
-                            <span className="text-base-content/30">—</span>
-                          )}
-                        </td>
-                      ))}
-                      <td className="text-right">
-                        {hasDetails(entry) && (
-                          <span
-                            className={`inline-block transition-transform duration-150 text-base-content/40 ${isOpen ? 'rotate-90' : ''}`}
-                            aria-hidden="true"
-                          >
-                            ›
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                    {isOpen && hasDetails(entry) && (
-                      <tr key={`${entry.id}-detail`} className="bg-base-100">
-                        <td
-                          colSpan={langOrder.length + 1}
-                          className="px-4 py-3"
-                        >
-                          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
-                            {entry.source && (
-                              <>
-                                <dt className="font-semibold text-base-content/60">
-                                  {t('terminology-source', lang)}
-                                </dt>
-                                <dd>{highlight(entry.source, query)}</dd>
-                              </>
-                            )}
-                            {entry.aliases && (
-                              <>
-                                <dt className="font-semibold text-base-content/60">
-                                  {t('terminology-aliases', lang)}
-                                </dt>
-                                <dd>
-                                  {highlight(
-                                    entry.aliases.replace(/\//g, ' / '),
-                                    query,
+                          {langOrder.map((l) => {
+                            const term = entry[l];
+                            return (
+                              <td
+                                key={l}
+                                className="align-top whitespace-nowrap"
+                              >
+                                {/* Main term */}
+                                <span
+                                  className={
+                                    l === (lang as LangCode)
+                                      ? 'font-medium'
+                                      : 'text-base-content/70'
+                                  }
+                                >
+                                  {term ? (
+                                    highlight(term, query)
+                                  ) : (
+                                    <span className="text-base-content/25">
+                                      —
+                                    </span>
                                   )}
-                                </dd>
-                              </>
+                                </span>
+
+                                {/* Abbreviation chip — shown in all columns */}
+                                {entry.abbr && term && (
+                                  <span className="ml-1.5 badge badge-xs badge-outline text-base-content/45 align-middle">
+                                    {highlight(entry.abbr, query)}
+                                  </span>
+                                )}
+
+                                {/* Aliases — zh-cn column only, as chips */}
+                                {l === 'zh-cn' && aliasList.length > 0 && (
+                                  <div className="mt-1 flex flex-wrap gap-0.5">
+                                    {aliasList.map((alias) => (
+                                      <span
+                                        key={alias}
+                                        className="badge badge-xs badge-ghost text-[10px] text-base-content/40"
+                                      >
+                                        {highlight(alias, query)}
+                                      </span>
+                                    ))}
+                                  </div>
+                                )}
+                              </td>
+                            );
+                          })}
+                          <td className="text-right align-top whitespace-nowrap">
+                            {canExpand && (
+                              <span
+                                className={`inline-block transition-transform duration-150 text-base-content/40 ${isOpen ? 'rotate-90' : ''}`}
+                                aria-hidden="true"
+                              >
+                                ›
+                              </span>
                             )}
-                            {entry.avoid && (
-                              <>
-                                <dt className="font-semibold text-error/80">
-                                  {t('terminology-avoid', lang)}
-                                </dt>
-                                <dd className="text-error/70">
-                                  {entry.avoid.replace(/\//g, ' / ')}
-                                </dd>
-                              </>
-                            )}
-                            {entry.disputed && (
-                              <>
-                                <dt className="font-semibold text-warning/80">
-                                  {t('terminology-disputed', lang)}
-                                </dt>
-                                <dd className="text-warning/70">
-                                  {entry.disputed.replace(/\//g, ' / ')}
-                                </dd>
-                              </>
-                            )}
-                            {entry.notes && (
-                              <>
-                                <dt className="font-semibold text-base-content/60 sm:col-span-2">
-                                  {t('terminology-notes', lang)}
-                                </dt>
-                                <dd className="sm:col-span-2 text-base-content/80">
-                                  {entry.notes}
-                                </dd>
-                              </>
-                            )}
-                            {entry.wikidata && (
-                              <>
-                                <dt className="font-semibold text-base-content/60">
-                                  Wikidata
-                                </dt>
-                                <dd>
-                                  <a
-                                    href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="link link-primary text-xs"
-                                    onClick={(ev) => ev.stopPropagation()}
-                                  >
-                                    {entry.wikidata}
-                                  </a>
-                                </dd>
-                              </>
-                            )}
-                          </dl>
-                        </td>
-                      </tr>
-                    )}
-                  </>
-                );
-              })
+                          </td>
+                        </tr>
+
+                        {/* Expanded detail row */}
+                        {isOpen && canExpand && (
+                          <tr
+                            key={`${entry.id}-detail`}
+                            className="bg-base-100"
+                          >
+                            <td colSpan={colCount} className="px-4 py-3">
+                              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                                {lang === 'zh-cn' && entry.avoid && (
+                                  <>
+                                    <dt className="font-semibold text-error/80">
+                                      {t('terminology-avoid', lang)}
+                                    </dt>
+                                    <dd className="text-error/70">
+                                      {entry.avoid.replace(/\//g, ' / ')}
+                                    </dd>
+                                  </>
+                                )}
+                                {lang === 'zh-cn' && entry.disputed && (
+                                  <>
+                                    <dt className="font-semibold text-warning/80">
+                                      {t('terminology-disputed', lang)}
+                                    </dt>
+                                    <dd className="text-warning/70">
+                                      {entry.disputed.replace(/\//g, ' / ')}
+                                    </dd>
+                                  </>
+                                )}
+                                {lang === 'zh-cn' && entry.notes && (
+                                  <>
+                                    <dt className="font-semibold text-base-content/60 sm:col-span-2">
+                                      {t('terminology-notes', lang)}
+                                    </dt>
+                                    <dd className="sm:col-span-2 text-base-content/80">
+                                      {entry.notes}
+                                    </dd>
+                                  </>
+                                )}
+                                {entry.wikidata && (
+                                  <>
+                                    <dt className="font-semibold text-base-content/60">
+                                      Wikidata
+                                    </dt>
+                                    <dd>
+                                      <a
+                                        href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="link link-primary text-xs font-mono"
+                                        onClick={(ev) => ev.stopPropagation()}
+                                      >
+                                        {entry.wikidata}
+                                      </a>
+                                    </dd>
+                                  </>
+                                )}
+                              </dl>
+                            </td>
+                          </tr>
+                        )}
+                      </>
+                    );
+                  })}
+                </>
+              ))
             )}
           </tbody>
         </table>

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -460,17 +460,26 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                                 {entry.wikidata && (
                                   <>
                                     <dt className="font-semibold text-base-content/60">
-                                      Wikipedia
+                                      Wikidata
                                     </dt>
-                                    <dd>
+                                    <dd className="flex items-center gap-2 flex-wrap">
                                       <a
-                                        href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${({ 'zh-cn': 'zh', 'zh-hant': 'zh', ja: 'ja', en: 'en', es: 'es' } as Record<string, string>)[lang] ?? 'en'}wiki/${entry.wikidata}`}
+                                        href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="link link-primary text-xs font-mono"
                                         onClick={(ev) => ev.stopPropagation()}
                                       >
                                         {entry.wikidata}
+                                      </a>
+                                      <a
+                                        href={`https://www.wikidata.org/wiki/Special:GoToLinkedPage/${({ 'zh-cn': 'zh', 'zh-hant': 'zh', ja: 'ja', en: 'en', es: 'es' } as Record<string, string>)[lang] ?? 'en'}wiki/${entry.wikidata}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="link link-primary text-xs"
+                                        onClick={(ev) => ev.stopPropagation()}
+                                      >
+                                        Wikipedia ↗
                                       </a>
                                     </dd>
                                   </>

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { t } from '@/lib/i18n/client';
+
+export interface TermEntry {
+  id: string;
+  wikidata: string;
+  'zh-cn': string;
+  'zh-hant': string;
+  ja: string;
+  en: string;
+  es: string;
+  source: string;
+  aliases: string;
+  avoid: string;
+  disputed: string;
+  notes: string;
+}
+
+interface Props {
+  data: string;
+  lang: string;
+}
+
+const LANG_ORDER = ['zh-cn', 'zh-hant', 'ja', 'en', 'es'] as const;
+type LangCode = (typeof LANG_ORDER)[number];
+
+const LANG_LABELS: Record<LangCode, string> = {
+  'zh-cn': '中文（简）',
+  'zh-hant': '中文（繁）',
+  ja: '日本語',
+  en: 'English',
+  es: 'Español',
+};
+
+function parseTsv(raw: string): TermEntry[] {
+  const lines = raw.trim().split('\n');
+  if (lines.length < 2) return [];
+  const headers = lines[0].split('\t');
+  return lines.slice(1).map((line) => {
+    const cells = line.split('\t');
+    return Object.fromEntries(
+      headers.map((h, i) => [h, cells[i] ?? '']),
+    ) as unknown as TermEntry;
+  });
+}
+
+function highlight(text: string, query: string): React.ReactNode {
+  if (!query || !text) return text;
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-warning/40 text-inherit rounded-sm px-0.5">
+        {text.slice(idx, idx + query.length)}
+      </mark>
+      {text.slice(idx + query.length)}
+    </>
+  );
+}
+
+export default function SearchableTerminologyTable({ data, lang }: Props) {
+  const [query, setQuery] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const entries = useMemo(() => parseTsv(data), [data]);
+
+  const langOrder = useMemo<LangCode[]>(() => {
+    const cur = lang as LangCode;
+    if (!LANG_ORDER.includes(cur)) return [...LANG_ORDER];
+    return [cur, ...LANG_ORDER.filter((l) => l !== cur)];
+  }, [lang]);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    if (!q) return entries;
+    return entries.filter((e) =>
+      [
+        e['zh-cn'],
+        e['zh-hant'],
+        e.ja,
+        e.en,
+        e.es,
+        e.source,
+        e.aliases,
+        e.notes,
+      ].some((v) => v?.toLowerCase().includes(q)),
+    );
+  }, [entries, query]);
+
+  const toggleExpand = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const hasDetails = (e: TermEntry) =>
+    e.source || e.aliases || e.avoid || e.disputed || e.notes;
+
+  const countText = t('terminology-count', lang)
+    .replace('{shown}', String(filtered.length))
+    .replace('{total}', String(entries.length));
+
+  return (
+    <div className="my-6 not-prose">
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <input
+          type="search"
+          className="input input-bordered input-sm flex-1 max-w-sm"
+          placeholder={t('terminology-search', lang)}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label={t('terminology-search', lang)}
+        />
+        <span className="text-sm text-base-content/60 self-center">
+          {countText}
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-base-300">
+        <table className="table table-xs table-pin-rows w-full">
+          <thead>
+            <tr className="bg-base-200">
+              {langOrder.map((l) => (
+                <th
+                  key={l}
+                  className={l === lang ? 'font-bold text-primary' : ''}
+                >
+                  {LANG_LABELS[l]}
+                </th>
+              ))}
+              <th className="w-6" aria-label="details" />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={langOrder.length + 1}
+                  className="text-center text-base-content/50 py-8"
+                >
+                  {t('terminology-no-results', lang)}
+                </td>
+              </tr>
+            ) : (
+              filtered.map((entry) => {
+                const isOpen = expanded.has(entry.id);
+                return (
+                  <>
+                    <tr
+                      key={entry.id}
+                      className="hover:bg-base-200/50 cursor-pointer"
+                      onClick={() =>
+                        hasDetails(entry) && toggleExpand(entry.id)
+                      }
+                      aria-expanded={hasDetails(entry) ? isOpen : undefined}
+                    >
+                      {langOrder.map((l) => (
+                        <td
+                          key={l}
+                          className={
+                            l === lang ? 'font-medium' : 'text-base-content/70'
+                          }
+                        >
+                          {highlight(entry[l], query) || (
+                            <span className="text-base-content/30">—</span>
+                          )}
+                        </td>
+                      ))}
+                      <td className="text-right">
+                        {hasDetails(entry) && (
+                          <span
+                            className={`inline-block transition-transform duration-150 text-base-content/40 ${isOpen ? 'rotate-90' : ''}`}
+                            aria-hidden="true"
+                          >
+                            ›
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                    {isOpen && hasDetails(entry) && (
+                      <tr key={`${entry.id}-detail`} className="bg-base-100">
+                        <td
+                          colSpan={langOrder.length + 1}
+                          className="px-4 py-3"
+                        >
+                          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                            {entry.source && (
+                              <>
+                                <dt className="font-semibold text-base-content/60">
+                                  {t('terminology-source', lang)}
+                                </dt>
+                                <dd>{highlight(entry.source, query)}</dd>
+                              </>
+                            )}
+                            {entry.aliases && (
+                              <>
+                                <dt className="font-semibold text-base-content/60">
+                                  {t('terminology-aliases', lang)}
+                                </dt>
+                                <dd>
+                                  {highlight(
+                                    entry.aliases.replace(/\//g, ' / '),
+                                    query,
+                                  )}
+                                </dd>
+                              </>
+                            )}
+                            {entry.avoid && (
+                              <>
+                                <dt className="font-semibold text-error/80">
+                                  {t('terminology-avoid', lang)}
+                                </dt>
+                                <dd className="text-error/70">
+                                  {entry.avoid.replace(/\//g, ' / ')}
+                                </dd>
+                              </>
+                            )}
+                            {entry.disputed && (
+                              <>
+                                <dt className="font-semibold text-warning/80">
+                                  {t('terminology-disputed', lang)}
+                                </dt>
+                                <dd className="text-warning/70">
+                                  {entry.disputed.replace(/\//g, ' / ')}
+                                </dd>
+                              </>
+                            )}
+                            {entry.notes && (
+                              <>
+                                <dt className="font-semibold text-base-content/60 sm:col-span-2">
+                                  {t('terminology-notes', lang)}
+                                </dt>
+                                <dd className="sm:col-span-2 text-base-content/80">
+                                  {entry.notes}
+                                </dd>
+                              </>
+                            )}
+                            {entry.wikidata && (
+                              <>
+                                <dt className="font-semibold text-base-content/60">
+                                  Wikidata
+                                </dt>
+                                <dd>
+                                  <a
+                                    href={`https://www.wikidata.org/wiki/${entry.wikidata}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="link link-primary text-xs"
+                                    onClick={(ev) => ev.stopPropagation()}
+                                  >
+                                    {entry.wikidata}
+                                  </a>
+                                </dd>
+                              </>
+                            )}
+                          </dl>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/wiki/components/SearchableTerminologyTable.tsx
+++ b/apps/wiki/components/SearchableTerminologyTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import { Fragment, useMemo, useRef, useState } from 'react';
 import { t } from '@/lib/i18n/client';
 
 export interface TermEntry {
@@ -322,9 +322,9 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
               </tr>
             ) : (
               grouped.map(({ category, entries: catEntries }) => (
-                <>
+                <Fragment key={category}>
                   {/* Category header */}
-                  <tr key={`cat-${category}`} className="bg-base-200/80">
+                  <tr className="bg-base-200/80">
                     <td
                       colSpan={colCount}
                       className="py-1 px-3 text-xs font-semibold uppercase tracking-wide text-base-content/50 whitespace-nowrap"
@@ -339,9 +339,8 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                     const canExpand = hasExpandContent(entry, lang);
 
                     return (
-                      <>
+                      <Fragment key={entry.id}>
                         <tr
-                          key={entry.id}
                           className={
                             canExpand
                               ? 'hover:bg-base-200/50 cursor-pointer'
@@ -532,10 +531,10 @@ export default function SearchableTerminologyTable({ data, lang }: Props) {
                             </td>
                           </tr>
                         )}
-                      </>
+                      </Fragment>
                     );
                   })}
-                </>
+                </Fragment>
               ))
             )}
           </tbody>

--- a/apps/wiki/lib/i18n/translations/translations.json
+++ b/apps/wiki/lib/i18n/translations/translations.json
@@ -159,5 +159,61 @@
     "ja": "現在のフォント",
     "es": "Fuente actual",
     "en": "Current Font"
+  },
+  "terminology-search": {
+    "zh-cn": "搜索术语…",
+    "zh-hant": "搜尋術語…",
+    "ja": "用語を検索…",
+    "es": "Buscar término…",
+    "en": "Search terms…"
+  },
+  "terminology-count": {
+    "zh-cn": "显示 {shown} / {total} 条",
+    "zh-hant": "顯示 {shown} / {total} 條",
+    "ja": "{shown} / {total} 件表示",
+    "es": "Mostrando {shown} de {total}",
+    "en": "Showing {shown} of {total}"
+  },
+  "terminology-no-results": {
+    "zh-cn": "无匹配结果",
+    "zh-hant": "無匹配結果",
+    "ja": "結果なし",
+    "es": "Sin resultados",
+    "en": "No results found"
+  },
+  "terminology-source": {
+    "zh-cn": "源术语",
+    "zh-hant": "源術語",
+    "ja": "原語",
+    "es": "Término fuente",
+    "en": "Source term"
+  },
+  "terminology-aliases": {
+    "zh-cn": "异名",
+    "zh-hant": "異名",
+    "ja": "異名",
+    "es": "Sinónimos",
+    "en": "Aliases"
+  },
+  "terminology-avoid": {
+    "zh-cn": "避免使用",
+    "zh-hant": "避免使用",
+    "ja": "使用を避ける",
+    "es": "Evitar",
+    "en": "Avoid"
+  },
+  "terminology-disputed": {
+    "zh-cn": "存在争议",
+    "zh-hant": "存在爭議",
+    "ja": "議論あり",
+    "es": "Disputado",
+    "en": "Disputed"
+  },
+  "terminology-notes": {
+    "zh-cn": "备注",
+    "zh-hant": "備註",
+    "ja": "備考",
+    "es": "Notas",
+    "en": "Notes"
   }
 }

--- a/apps/wiki/lib/i18n/translations/translations.json
+++ b/apps/wiki/lib/i18n/translations/translations.json
@@ -215,5 +215,12 @@
     "ja": "備考",
     "es": "Notas",
     "en": "Notes"
+  },
+  "terminology-columns": {
+    "zh-cn": "列",
+    "zh-hant": "欄",
+    "ja": "列",
+    "es": "Columnas",
+    "en": "Columns"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `SearchableTerminologyTable` — a `'use client'` React component that parses the TSV data and renders a searchable, filterable, expandable terminology table
- Adds `remarkTerminologyGlossary` — a remark plugin that replaces `{{< terminology-glossary >}}` shortcode nodes with `<SearchableTerminologyTable data={…} lang={…} />`, injecting pre-loaded TSV content at build time
- Adds 9 i18n keys to `translations.json` for all 5 languages (search placeholder, row count, no-results, column labels)

## Component features

- Real-time search across all language columns and aliases
- Category group headers (identity, HRT, surgery, voice, …)
- Expandable rows: aliases per language (as chips), avoid/disputed flags, notes, Wikidata QID + locale Wikipedia + English Wikipedia links
- Column visibility toggle (hide/show individual language columns)
- Abbreviation badges (`abbr` field) displayed inline
- `W` indicator on rows with a linked Wikidata item
- DaisyUI 5 / Tailwind CSS 4 styling, dark/light mode compatible

## Dependency

**Requires https://github.com/project-trans/MtF-wiki/pull/1724 to be merged first** so that `data/terminology.tsv` is available via the `source/` submodule at build time.

## Test plan

- [ ] `pnpm dev` builds without TypeScript errors
- [ ] `/zh-cn/docs/terminology`, `/ja/docs/terminology`, `/en/docs/terminology` etc. all render the table
- [ ] Search filters rows in real-time across all 5 language columns
- [ ] Expanding a row shows aliases, Wikidata links, notes
- [ ] Column toggle hides/shows language columns
- [ ] Light and dark mode both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 摘要

- 新增 `SearchableTerminologyTable` — 一个 `'use client'` React 组件，解析 TSV 数据并渲染为可搜索、可筛选、可展开的术语表格
- 新增 `remarkTerminologyGlossary` — 一个 remark 插件，将 `{{< terminology-glossary >}}` 短代码节点替换为 `<SearchableTerminologyTable data={…} lang={…} />`，在构建时注入预加载的 TSV 内容
- 在 `translations.json` 中为全部 5 种语言新增 9 个 i18n 键（搜索占位符、行数统计、无结果提示、列标题）

## 组件功能

- 跨所有语言列及异名的实时搜索
- 分类分组表头（认同、HRT、手术、嗓音……）
- 可展开行：各语言异名（以标签形式）、避免用词/争议标记、备注、Wikidata QID + 当前语言维基百科 + 英文维基百科链接
- 列可见性切换（可隐藏/显示各语言列）
- 内联显示缩写徽章（`abbr` 字段）
- 有 Wikidata 关联条目的行显示 `W` 指示标记
- 基于 DaisyUI 5 / Tailwind CSS 4，兼容深色/浅色模式

## 依赖关系

**需先合并 https://github.com/project-trans/MtF-wiki/pull/1724** ，以确保 `data/terminology.tsv` 在构建时可通过 `source/` 子模块访问。

## 测试计划

- [ ] `pnpm dev` 构建通过，无 TypeScript 错误
- [ ] `/zh-cn/docs/terminology`、`/ja/docs/terminology`、`/en/docs/terminology` 等页面均能正常渲染表格
- [ ] 搜索框可实时筛选所有 5 种语言列的行
- [ ] 展开行后显示异名、Wikidata 链接、备注
- [ ] 列切换功能正常隐藏/显示语言列
- [ ] 浅色和深色模式下显示均正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)