### PR TITLE
feat(wiki): localize cup-calculator and converter to all 5 languages

### DIFF
--- a/apps/wiki/app/[language]/converter/components/ConversionTooltip.tsx
+++ b/apps/wiki/app/[language]/converter/components/ConversionTooltip.tsx
@@ -1,21 +1,24 @@
 import { HelpCircle } from 'lucide-react';
+import { t } from '@/lib/i18n/client';
 import type { HormoneRange } from '../lib/types';
 import { formatRangeText } from '../lib/utils';
 
 interface ConversionTooltipProps {
   originalRange: HormoneRange;
   isVisible: boolean;
+  language: string;
 }
 
 export function ConversionTooltip({
   originalRange,
   isVisible,
+  language,
 }: ConversionTooltipProps) {
   if (!isVisible) {
     return null;
   }
 
-  const tooltipContent = `转换自：${formatRangeText(
+  const tooltipContent = `${t('conv-converted-from', language)}：${formatRangeText(
     originalRange.min,
     originalRange.max,
     originalRange.hideMax,

--- a/apps/wiki/app/[language]/converter/components/HelpTooltip.tsx
+++ b/apps/wiki/app/[language]/converter/components/HelpTooltip.tsx
@@ -3,8 +3,13 @@
 import { HelpCircle, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
+import { t } from '@/lib/i18n/client';
 
-export function HelpTooltip() {
+interface HelpTooltipProps {
+  language: string;
+}
+
+export function HelpTooltip({ language }: HelpTooltipProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -13,7 +18,7 @@ export function HelpTooltip() {
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="btn btn-circle btn-ghost btn-sm"
-        title="使用帮助"
+        title={t('conv-help', language) as string}
       >
         <HelpCircle className="w-4 h-4" />
       </button>
@@ -27,7 +32,9 @@ export function HelpTooltip() {
             className="absolute right-0 top-full mt-2 w-80 bg-base-100 rounded-lg shadow-xl border border-base-300 p-4 z-50"
           >
             <div className="flex items-center justify-between mb-3">
-              <h3 className="font-semibold text-base-content">使用帮助</h3>
+              <h3 className="font-semibold text-base-content">
+                {t('conv-help', language)}
+              </h3>
               <button
                 type="button"
                 onClick={() => setIsOpen(false)}
@@ -39,20 +46,23 @@ export function HelpTooltip() {
 
             <div className="space-y-3 text-sm text-base-content/80">
               <div>
-                <h4 className="font-medium text-base-content mb-1">基本操作</h4>
+                <h4 className="font-medium text-base-content mb-1">
+                  {t('conv-help-basic', language)}
+                </h4>
                 <ul className="space-y-1 text-xs">
-                  <li>• 选择激素类型</li>
-                  <li>• 输入数值和选择单位</li>
-                  <li>• 查看自动转换结果</li>
-                  <li>• 点击复制按钮复制结果</li>
+                  <li>• {t('conv-help-step1', language)}</li>
+                  <li>• {t('conv-help-step2', language)}</li>
+                  <li>• {t('conv-help-step3', language)}</li>
+                  <li>• {t('conv-help-step4', language)}</li>
                 </ul>
               </div>
 
               <div>
-                <h4 className="font-medium text-base-content mb-1">范围提示</h4>
+                <h4 className="font-medium text-base-content mb-1">
+                  {t('conv-help-ranges-title', language)}
+                </h4>
                 <p className="text-xs">
-                  转换结果有时会显示颜色标识，表示数值是否属于特定的参考范围。
-                  请注意这些范围仅供参考，具体请咨询医生。
+                  {t('conv-help-ranges-text', language)}
                 </p>
               </div>
             </div>

--- a/apps/wiki/app/[language]/converter/components/HistoryPanel.tsx
+++ b/apps/wiki/app/[language]/converter/components/HistoryPanel.tsx
@@ -1,12 +1,17 @@
 'use client';
 
 import { useAtom } from 'jotai';
-import { motion, AnimatePresence } from 'motion/react';
-import { historyAtom, clearHistoryAtom, showHistoryAtom } from '../lib/atoms';
+import { Clock, Trash2, X } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { type TranslationKey, t } from '@/lib/i18n/client';
+import { clearHistoryAtom, historyAtom, showHistoryAtom } from '../lib/atoms';
 import { formatTimestamp, formatValue, getHormoneById } from '../lib/utils';
-import { Trash2, Clock, X } from 'lucide-react';
 
-export function HistoryPanel() {
+interface HistoryPanelProps {
+  language: string;
+}
+
+export function HistoryPanel({ language }: HistoryPanelProps) {
   const [history] = useAtom(historyAtom);
   const [, clearHistory] = useAtom(clearHistoryAtom);
   const [showHistory, setShowHistory] = useAtom(showHistoryAtom);
@@ -32,7 +37,9 @@ export function HistoryPanel() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Clock className="w-5 h-5 text-primary" />
-              <h2 className="text-xl font-semibold">换算历史</h2>
+              <h2 className="text-xl font-semibold">
+                {t('conv-history-title', language)}
+              </h2>
               <span className="badge badge-primary">{history.length}</span>
             </div>
             <div className="flex items-center gap-2">
@@ -43,7 +50,7 @@ export function HistoryPanel() {
                   className="btn btn-ghost btn-sm text-error"
                 >
                   <Trash2 className="w-4 h-4" />
-                  清空
+                  {t('conv-clear', language)}
                 </button>
               )}
               <button
@@ -56,7 +63,7 @@ export function HistoryPanel() {
             </div>
           </div>
           <p className="text-sm text-base-content/60 mt-2">
-            数据仅存储在浏览器本地，不会上传到服务器
+            {t('conv-history-storage', language)}
           </p>
         </div>
 
@@ -69,7 +76,7 @@ export function HistoryPanel() {
                 className="p-8 text-center text-base-content/60"
               >
                 <Clock className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                <p>暂无换算历史</p>
+                <p>{t('conv-history-empty', language)}</p>
               </motion.div>
             ) : (
               <div className="p-4 space-y-3">
@@ -85,10 +92,12 @@ export function HistoryPanel() {
                     >
                       <div className="flex items-center justify-between mb-2">
                         <span className="font-medium text-primary">
-                          {hormone?.name || '未知激素'}
+                          {hormone
+                            ? t(hormone.name as TranslationKey, language)
+                            : t('conv-unknown-hormone', language)}
                         </span>
                         <span className="text-xs text-base-content/60">
-                          {formatTimestamp(record.timestamp)}
+                          {formatTimestamp(record.timestamp, language)}
                         </span>
                       </div>
                       <div className="text-sm">

--- a/apps/wiki/app/[language]/converter/components/HormoneCard.tsx
+++ b/apps/wiki/app/[language]/converter/components/HormoneCard.tsx
@@ -4,16 +4,13 @@ import { useAtom } from 'jotai';
 import { ArrowUpDown, Calculator, Check, Copy, Info, X } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
+import { type TranslationKey, t } from '@/lib/i18n/client';
 import { addHistoryRecordAtom, conversionStateAtom } from '../lib/atoms';
 import type { HormoneType } from '../lib/types';
-import { formatValue, performConversion } from '../lib/utils';
-import { isIUStandard } from '../lib/utils';
+import { formatValue, isIUStandard, performConversion } from '../lib/utils';
 import { RangeIndicator } from './RangeIndicator';
 import { UnitSelector } from './UnitSelector';
 
-/**
- * 判断是否为IU和质量单位之间的换算
- */
 function isIUToMassConversion(fromUnit: string, toUnit: string): boolean {
   const fromIsIU = isIUStandard(fromUnit);
   const toIsIU = isIUStandard(toUnit);
@@ -23,9 +20,10 @@ function isIUToMassConversion(fromUnit: string, toUnit: string): boolean {
 
 interface HormoneCardProps {
   hormone: HormoneType;
+  language: string;
 }
 
-export function HormoneCard({ hormone }: HormoneCardProps) {
+export function HormoneCard({ hormone, language }: HormoneCardProps) {
   const [state, setState] = useAtom(conversionStateAtom);
   const [, addHistoryRecord] = useAtom(addHistoryRecordAtom);
   const [isConverting, setIsConverting] = useState(false);
@@ -36,7 +34,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
 
   const pendingResult = useRef<any>(null);
 
-  // 当激素类型改变时，重置单位选择
   useEffect(() => {
     if (isSelected && state.fromUnit && state.toUnit) {
       const fromUnitExists = hormone.units.some(
@@ -55,7 +52,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
     }
   }, [hormone, isSelected, state.fromUnit, state.toUnit, setState]);
 
-  // 当激素类型、单位或输入值改变时重新计算结果
   useEffect(() => {
     if (pendingResult.current) {
       clearTimeout(pendingResult.current);
@@ -67,7 +63,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
     const trimmedInput = state.inputValue.trim();
 
     function setErrorState() {
-      // 输入不为空但无效（包含汉字等），设置无效结果
       setState((prev) => ({
         ...prev,
         result: {
@@ -81,10 +76,8 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
     if (trimmedInput && !inputRef.current?.checkValidity()) {
       setErrorState();
     } else if (trimmedInput && !Number.isNaN(Number.parseFloat(trimmedInput))) {
-      // 输入有效，进行转换
       setIsConverting(true);
 
-      // 添加轻微延迟以显示动画效果
       pendingResult.current = setTimeout(() => {
         const result = performConversion(
           state.inputValue,
@@ -99,7 +92,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
     } else if (trimmedInput) {
       setErrorState();
     } else {
-      // 输入为空，清除结果
       setState((prev) => ({ ...prev, result: null }));
       setIsConverting(false);
     }
@@ -114,7 +106,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
 
   const handleInputChange = (value: string) => {
     setState((prev) => ({ ...prev, inputValue: value }));
-    // 转换计算现在由useEffect处理，避免重复计算
   };
 
   const handleUnitChange = (type: 'from' | 'to', unit: string) => {
@@ -122,7 +113,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
       ...prev,
       [type === 'from' ? 'fromUnit' : 'toUnit']: unit,
     }));
-    // 转换计算现在由useEffect处理，避免重复计算
   };
 
   const swapUnits = () => {
@@ -140,7 +130,6 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
       result: null,
     }));
 
-    // 如果交换后有输入值，立即计算结果
     if (newInputValue && !Number.isNaN(Number.parseFloat(newInputValue))) {
       setIsConverting(true);
       clearTimeout(pendingResult.current);
@@ -206,22 +195,16 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
     >
       <div className="bg-gradient-to-r from-primary/10 to-secondary/10 p-4 md:p-6 border-b border-base-300/30">
         <h3 className="text-xl font-semibold text-base-content">
-          {hormone.name}
+          {t(hormone.name as TranslationKey, language)}
         </h3>
-        {/* {hormone.description && (
-          <p className="text-sm text-base-content/60 mt-1">
-            {hormone.description}
-          </p>
-        )} */}
       </div>
 
       <div className="p-4 md:p-6">
         <div className="space-y-4 md:space-y-6">
-          {/* 输入部分 */}
           <div className="space-y-3 md:space-y-4">
             {/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
             <label className="block text-sm font-medium text-base-content">
-              输入数值
+              {t('conv-input-value', language)}
             </label>
             <div className="flex gap-2">
               <div className="relative flex-1">
@@ -232,7 +215,7 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
                   pattern="[0-9.]*"
                   value={state.inputValue}
                   onChange={(e) => handleInputChange(e.target.value)}
-                  placeholder="请输入数值"
+                  placeholder={t('conv-input-placeholder', language) as string}
                   className="input input-bordered w-full pr-10 text-base"
                   min="0"
                 />
@@ -242,7 +225,7 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
                     className="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs btn-circle"
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.9 }}
-                    title="清空输入"
+                    title={t('conv-clear-input', language) as string}
                   >
                     <X className="w-3 h-3" />
                   </motion.button>
@@ -252,29 +235,28 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
                 value={state.fromUnit}
                 onChange={(unit) => handleUnitChange('from', unit)}
                 units={hormone.units}
+                language={language}
                 className="w-fit"
               />
             </div>
           </div>
 
-          {/* 转换箭头和交换按钮 */}
           <div className="flex items-center justify-center mb-0">
             <motion.button
               onClick={swapUnits}
               className="btn btn-circle btn-ghost"
               whileHover={{ scale: 1.1 }}
               whileTap={{ scale: 0.9 }}
-              title="交换单位"
+              title={t('conv-swap-units', language) as string}
             >
               <ArrowUpDown className="w-5 h-5" />
             </motion.button>
           </div>
 
-          {/* 输出部分 */}
           <div className="space-y-4">
             {/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
             <label className="block text-sm font-medium text-base-content">
-              转换结果
+              {t('conv-result-label', language)}
             </label>
             <div className="flex items-center gap-3 flex-wrap">
               <div className="flex-1 p-4 bg-base-200/50 rounded-lg border border-base-300/30 min-h-[60px] flex items-center max-w-full">
@@ -302,7 +284,7 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
                   className="btn btn-ghost btn-square"
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
-                  title="复制结果"
+                  title={t('conv-copy-result', language) as string}
                 >
                   {isCopied ? (
                     <Check className="w-4 h-4 text-success" />
@@ -315,22 +297,21 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
                 value={state.toUnit}
                 onChange={(unit) => handleUnitChange('to', unit)}
                 units={hormone.units}
+                language={language}
                 className="w-fit"
               />
             </div>
 
-            {/* IU和质量单位换算提示 */}
             {isIUToMassConversion(state.fromUnit, state.toUnit) && (
               <div className="alert alert-info alert-soft">
                 <Info className="w-6 h-6" />
                 <span className="text-sm">
-                  IU 和质量单位之间的换算结果仅供参考。
+                  {t('conv-iu-mass-warning', language)}
                 </span>
               </div>
             )}
           </div>
 
-          {/* 操作按钮 */}
           <div className="flex justify-center">
             <motion.button
               disabled={!state.result?.isValid || isConverting}
@@ -340,15 +321,15 @@ export function HormoneCard({ hormone }: HormoneCardProps) {
               whileTap={{ scale: 0.98 }}
             >
               <Calculator className="w-4 h-4" />
-              转换
+              {t('conv-convert', language)}
             </motion.button>
           </div>
         </div>
 
-        {/* 范围指示器 */}
         <RangeIndicator
           ranges={state.result?.ranges}
           isVisible={state.result?.isValid === true}
+          language={language}
         />
       </div>
     </motion.div>

--- a/apps/wiki/app/[language]/converter/components/HormoneConverter.tsx
+++ b/apps/wiki/app/[language]/converter/components/HormoneConverter.tsx
@@ -3,6 +3,7 @@
 import { useAtom } from 'jotai';
 import { Beaker, Clock } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
+import { type TranslationKey, t } from '@/lib/i18n/client';
 import {
   historyAtom,
   selectedHormoneAtom,
@@ -13,16 +14,24 @@ import { HistoryPanel } from './HistoryPanel';
 import { HormoneCard } from './HormoneCard';
 import { ReferenceRanges } from './ReferenceRanges';
 
-export function HormoneConverter() {
+interface HormoneConverterProps {
+  language: string;
+}
+
+export function HormoneConverter({ language }: HormoneConverterProps) {
   const [selectedHormone, setSelectedHormone] = useAtom(selectedHormoneAtom);
   const [, setShowHistory] = useAtom(showHistoryAtom);
   const [history] = useAtom(historyAtom);
 
   const selectedHormoneData = HORMONES.find((h) => h.id === selectedHormone);
 
+  const unitsCountText = (t('conv-units-count', language) as string).replace(
+    '{count}',
+    '0',
+  );
+
   return (
     <div className="space-y-8">
-      {/* 激素类型选择 */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -30,10 +39,11 @@ export function HormoneConverter() {
       >
         <div className="flex items-center gap-2 mb-4">
           <Beaker className="w-5 h-5 text-primary" />
-          <h2 className="text-lg font-semibold">选择激素类型</h2>
+          <h2 className="text-lg font-semibold">
+            {t('conv-select-hormone', language)}
+          </h2>
         </div>
 
-        {/* 移动端下拉选择 */}
         <div className="block md:hidden mb-4">
           <select
             value={selectedHormone}
@@ -42,13 +52,12 @@ export function HormoneConverter() {
           >
             {HORMONES.map((hormone) => (
               <option key={hormone.id} value={hormone.id}>
-                {hormone.name}
+                {t(hormone.name as TranslationKey, language)}
               </option>
             ))}
           </select>
         </div>
 
-        {/* 桌面端网格选择 */}
         <div className="hidden md:grid grid-cols-2 lg:grid-cols-3 gap-4">
           {HORMONES.map((hormone) => (
             <motion.button
@@ -63,31 +72,31 @@ export function HormoneConverter() {
               whileTap={{ scale: 0.98 }}
             >
               <div className="font-medium text-base-content text-sm">
-                {hormone.name}
+                {t(hormone.name as TranslationKey, language)}
               </div>
               <div className="text-xs text-base-content/60 mt-1">
-                {hormone.units.length} 种单位
+                {(t('conv-units-count', language) as string).replace(
+                  '{count}',
+                  hormone.units.length.toString(),
+                )}
               </div>
             </motion.button>
           ))}
         </div>
       </motion.div>
 
-      {/* 主要内容区域 - 大屏设备水平布局，小屏设备垂直布局 */}
       <div className="grid grid-cols-1 lg:grid-cols-7 gap-4 md:gap-8">
-        {/* 左侧：换算器界面和功能按钮 */}
         <div className="lg:col-span-4 space-y-4 md:space-y-8">
-          {/* 换算器界面 */}
           <AnimatePresence>
             {selectedHormoneData && (
               <HormoneCard
                 key={selectedHormone}
                 hormone={selectedHormoneData}
+                language={language}
               />
             )}
           </AnimatePresence>
 
-          {/* 功能按钮 */}
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -100,7 +109,7 @@ export function HormoneConverter() {
               className="btn btn-outline gap-2"
             >
               <Clock className="w-4 h-4" />
-              查看历史
+              {t('conv-view-history', language)}
               {history.length > 0 && (
                 <span className="badge badge-primary badge-sm">
                   {history.length}
@@ -110,21 +119,20 @@ export function HormoneConverter() {
           </motion.div>
         </div>
 
-        {/* 右侧：参考范围说明 */}
         <div className="lg:col-span-3">
           <AnimatePresence>
             {selectedHormoneData && (
               <ReferenceRanges
                 key={selectedHormone}
                 hormone={selectedHormoneData}
+                language={language}
               />
             )}
           </AnimatePresence>
         </div>
       </div>
 
-      {/* 历史记录面板 */}
-      <HistoryPanel />
+      <HistoryPanel language={language} />
     </div>
   );
 }

--- a/apps/wiki/app/[language]/converter/components/RangeIndicator.tsx
+++ b/apps/wiki/app/[language]/converter/components/RangeIndicator.tsx
@@ -10,11 +10,13 @@ import {
   XCircle,
 } from 'lucide-react';
 import { motion } from 'motion/react';
+import { type TranslationKey, t } from '@/lib/i18n/client';
 import type { HormoneRange } from '../lib/types';
 
 interface RangeIndicatorProps {
   ranges?: HormoneRange[];
   isVisible: boolean;
+  language: string;
 }
 
 // MtF 主题色配置
@@ -82,7 +84,11 @@ function getIconComponent(iconType?: string) {
   }
 }
 
-export function RangeIndicator({ ranges, isVisible }: RangeIndicatorProps) {
+export function RangeIndicator({
+  ranges,
+  isVisible,
+  language,
+}: RangeIndicatorProps) {
   if (!isVisible || !ranges || ranges.length === 0) {
     return null;
   }
@@ -116,10 +122,12 @@ export function RangeIndicator({ ranges, isVisible }: RangeIndicatorProps) {
               />
               <div>
                 <div className="font-medium text-base-content">
-                  {range.label}
+                  {t(range.label as TranslationKey, language)}
                 </div>
                 <div className="text-sm text-base-content/70">
-                  {range.description}
+                  {range.description
+                    ? t(range.description as TranslationKey, language)
+                    : ''}
                 </div>
               </div>
             </div>

--- a/apps/wiki/app/[language]/converter/components/ReferenceRanges.tsx
+++ b/apps/wiki/app/[language]/converter/components/ReferenceRanges.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Link } from '@/components/progress';
 import { useAtom } from 'jotai';
 import { Calculator } from 'lucide-react';
 import { motion } from 'motion/react';
+import { Link } from '@/components/progress';
+import { type TranslationKey, t } from '@/lib/i18n/client';
 import { conversionStateAtom } from '../lib/atoms';
 import type { HormoneType } from '../lib/types';
 import {
@@ -16,11 +17,9 @@ import { ConversionTooltip } from './ConversionTooltip';
 
 interface ReferenceRangesProps {
   hormone: HormoneType;
+  language: string;
 }
 
-/**
- * 判断是否应该跳过单位转换显示
- */
 function shouldSkipUnitConversion(
   rangeUnit: string,
   fromUnit: string,
@@ -37,20 +36,15 @@ function shouldSkipUnitConversion(
   return true;
 }
 
-/**
- * 判断是否应该显示转换tooltip
- */
 function shouldShowConversionTooltip(
   rangeUnit: string,
   displayUnit: string,
   hormone: HormoneType,
 ): boolean {
-  // 如果单位相同，不需要tooltip
   if (rangeUnit === displayUnit) {
     return false;
   }
 
-  // 如果单位等价，不需要tooltip
   if (areUnitsEquivalent(hormone, rangeUnit, displayUnit)) {
     return false;
   }
@@ -58,14 +52,12 @@ function shouldShowConversionTooltip(
   return true;
 }
 
-export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
+export function ReferenceRanges({ hormone, language }: ReferenceRangesProps) {
   const [state] = useAtom(conversionStateAtom);
 
-  // 获取当前选择的单位
   const fromUnit = state.fromUnit;
   const toUnit = state.toUnit;
 
-  // 检查两个单位是否等价
   const unitsAreEquivalent = areUnitsEquivalent(hormone, fromUnit, toUnit);
 
   const visibleRanges = hormone.ranges.filter(
@@ -81,12 +73,13 @@ export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
     >
       <div className="flex items-center gap-2 mb-4">
         <Calculator className="w-5 h-5 text-info" />
-        <h3 className="text-lg font-semibold">参考范围说明</h3>
+        <h3 className="text-lg font-semibold">
+          {t('conv-reference-ranges', language)}
+        </h3>
       </div>
       {visibleRanges.length > 0 ? (
         <div className="space-y-4">
           {visibleRanges.map((range, index) => {
-            // 转换范围到fromUnit和toUnit
             const fromUnitRange = convertRangeToUnit(range, fromUnit, hormone);
             const toUnitRange = convertRangeToUnit(range, toUnit, hormone);
 
@@ -107,13 +100,12 @@ export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
                 }`}
               >
                 <div className="font-medium text-base-content">
-                  {range.label}
+                  {t(range.label as TranslationKey, language)}
                 </div>
                 <div className="text-sm text-base-content/70 mt-1">
                   {!fromUnitRange ||
                   !toUnitRange ||
                   shouldSkipUnitConversion(range.unit, fromUnit, toUnit) ? (
-                    // 转换失败或需要跳过转换时，只显示原始单位
                     <>
                       {formatRangeText(range.min, range.max, range.hideMax)}{' '}
                       {range.unit}
@@ -133,10 +125,10 @@ export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
                           fromUnit,
                           hormone,
                         )}
+                        language={language}
                       />
                     </>
                   ) : (
-                    // 其他情况显示两种单位的范围
                     <>
                       {formatRangeText(
                         fromUnitRange.min,
@@ -151,6 +143,7 @@ export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
                           fromUnit,
                           hormone,
                         )}
+                        language={language}
                       />
                       <span className="text-base-content/50 mx-2">|</span>
                       {formatRangeText(
@@ -166,24 +159,28 @@ export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
                           toUnit,
                           hormone,
                         )}
+                        language={language}
                       />
                     </>
                   )}
                 </div>
                 {range.description && (
                   <div className="text-xs text-base-content/60 mt-1">
-                    {range.description}
+                    {t(range.description as TranslationKey, language)}
                   </div>
                 )}
                 {range.source && (
                   <div className="text-xs text-base-content/50 mt-1 italic">
-                    数据来源：
+                    {t('conv-data-source', language)}：
                     <Link
-                      href={range.source.url}
+                      href={range.source.url.replace(
+                        '/zh-cn/',
+                        `/${language}/`,
+                      )}
                       className="link link-primary hover:link-accent transition-colors"
                       rel="noopener noreferrer"
                     >
-                      {range.source.name}
+                      {t(range.source.name as TranslationKey, language)}
                     </Link>
                   </div>
                 )}
@@ -192,7 +189,9 @@ export function ReferenceRanges({ hormone }: ReferenceRangesProps) {
           })}
         </div>
       ) : (
-        <div className="text-sm text-base-content/60">暂无参考范围</div>
+        <div className="text-sm text-base-content/60">
+          {t('conv-no-ranges', language)}
+        </div>
       )}
     </motion.div>
   );

--- a/apps/wiki/app/[language]/converter/components/UnitSelector.tsx
+++ b/apps/wiki/app/[language]/converter/components/UnitSelector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { t } from '@/lib/i18n/client';
 import type { HormoneUnit } from '../lib/types';
 
 interface CombinedHormoneUnit extends HormoneUnit {
@@ -17,13 +18,11 @@ interface UnitSelectorProps {
   value: string;
   onChange: (value: string) => void;
   units: HormoneUnit[];
+  language: string;
   className?: string;
 }
 
-/**
- * 处理等价单位合并和分组
- */
-function processUnits(units: HormoneUnit[]): UnitGroup[] {
+function processUnits(units: HormoneUnit[], language: string): UnitGroup[] {
   // 按 multiplier 分组，找出等价单位
   const multiplierGroups = new Map<string, HormoneUnit[]>();
 
@@ -89,14 +88,14 @@ function processUnits(units: HormoneUnit[]): UnitGroup[] {
 
   if (commonUnits.length > 0) {
     groups.push({
-      label: '常用单位',
+      label: t('conv-common-units', language) as string,
       units: commonUnits,
     });
   }
 
   if (uncommonUnits.length > 0) {
     groups.push({
-      label: '其他单位',
+      label: t('conv-other-units', language) as string,
       units: uncommonUnits,
     });
   }
@@ -108,9 +107,13 @@ export function UnitSelector({
   value,
   onChange,
   units,
+  language,
   className = '',
 }: UnitSelectorProps) {
-  const groups = useMemo(() => processUnits(units), [units]);
+  const groups = useMemo(
+    () => processUnits(units, language),
+    [units, language],
+  );
 
   const realValue = useMemo(() => {
     for (const group of groups) {

--- a/apps/wiki/app/[language]/converter/lib/utils.ts
+++ b/apps/wiki/app/[language]/converter/lib/utils.ts
@@ -1,4 +1,5 @@
 import { format } from 'd3-format';
+import { t } from '@/lib/i18n/client';
 import { HORMONES } from './constants';
 import type {
   ConversionResult,
@@ -203,10 +204,15 @@ export function formatRangeText(
   }
 }
 
-/**
- * 格式化时间戳
- */
-export function formatTimestamp(timestamp: number): string {
+const LOCALE_MAP: Record<string, string> = {
+  'zh-cn': 'zh-CN',
+  'zh-hant': 'zh-TW',
+  ja: 'ja-JP',
+  en: 'en-US',
+  es: 'es-ES',
+};
+
+export function formatTimestamp(timestamp: number, language = 'zh-cn'): string {
   const date = new Date(timestamp);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
@@ -215,14 +221,23 @@ export function formatTimestamp(timestamp: number): string {
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
   if (diffMins < 1) {
-    return '刚刚';
+    return t('time-just-now', language) as string;
   } else if (diffMins < 60) {
-    return `${diffMins}分钟前`;
+    return (t('time-minutes-ago', language) as string).replace(
+      '{n}',
+      diffMins.toString(),
+    );
   } else if (diffHours < 24) {
-    return `${diffHours}小时前`;
+    return (t('time-hours-ago', language) as string).replace(
+      '{n}',
+      diffHours.toString(),
+    );
   } else if (diffDays < 7) {
-    return `${diffDays}天前`;
+    return (t('time-days-ago', language) as string).replace(
+      '{n}',
+      diffDays.toString(),
+    );
   } else {
-    return date.toLocaleDateString('zh-CN');
+    return date.toLocaleDateString(LOCALE_MAP[language] || 'en-US');
   }
 }

--- a/apps/wiki/app/[language]/converter/page.tsx
+++ b/apps/wiki/app/[language]/converter/page.tsx
@@ -1,6 +1,6 @@
-import SuggestionBox from '@/components/SuggestionBox';
 import { Link } from '@/components/progress';
-import { HelpTooltip } from './components/HelpTooltip';
+import SuggestionBox from '@/components/SuggestionBox';
+import { t } from '@/lib/i18n/client';
 import { HormoneConverter } from './components/HormoneConverter';
 
 export async function generateMetadata({
@@ -10,49 +10,53 @@ export async function generateMetadata({
 }) {
   const { language } = await params;
   return {
-    title: '激素换算器 - MtF.wiki',
+    title: `${t('conv-page-title', language)} - MtF.wiki`,
   };
 }
-export default function ConverterPage() {
+
+export default async function ConverterPage({
+  params,
+}: {
+  params: Promise<{ language: string }>;
+}) {
+  const { language } = await params;
   return (
     <div className="container mx-auto px-4 py-6 md:py-8">
       <div className="max-w-6xl mx-auto">
         <header className="text-center mb-6 md:mb-8 relative">
           <div className="flex items-center justify-center gap-4 mb-4">
-            <h1 className="text-4xl font-bold text-base-content">激素换算器</h1>
+            <h1 className="text-4xl font-bold text-base-content">
+              {t('conv-page-title', language)}
+            </h1>
           </div>
           <p className="text-sm">
-            有关单位转换的具体规则，请参见{' '}
-            <Link href="/zh-cn/converter/science-literacy" className="link">
-              单位科普
+            {t('conv-page-intro', language)}{' '}
+            <Link
+              href={`/${language}/converter/science-literacy`}
+              className="link"
+            >
+              {t('conv-science-literacy', language)}
             </Link>
             {' 。'}
           </p>
         </header>
-        <HormoneConverter />
+        <HormoneConverter language={language} />
 
         <footer className="mt-8 md:mt-12 p-4 md:p-6 bg-base-200/50 rounded-xl">
           <div className="text-sm text-base-content/60 space-y-2">
             <p>
-              <strong>注意：</strong>部分医院可能使用
+              <strong>{t('conv-note-prefix', language)}：</strong>
+              {t('conv-iu-note', language)} {t('conv-detail-see', language)}{' '}
               <Link
-                href="https://zh.wikipedia.org/wiki/%E5%9B%BD%E9%99%85%E5%8D%95%E4%BD%8D"
-                target="_blank"
-                className="link"
-              >
-                IU（国际单位）
-              </Link>
-              作为衡量激素水平的单位，但由于IU为医学效价单位，其与质量单位的换算取决于药物种类且可能随时间变化。详见{' '}
-              <Link
-                href="/zh-cn/converter/science-literacy"
+                href={`/${language}/converter/science-literacy`}
                 className="link link-primary"
               >
-                单位科普 - 国际单位（IU）
+                {t('conv-iu-detail-link', language)}
               </Link>
             </p>
             <p>
-              <strong>数据存储说明：</strong>
-              您的换算历史记录仅存储在浏览器本地，不会上传到服务器。
+              <strong>{t('conv-data-storage', language)}：</strong>
+              {t('conv-history-note', language)}
             </p>
           </div>
         </footer>
@@ -65,5 +69,11 @@ export default function ConverterPage() {
 }
 
 export async function generateStaticParams() {
-  return [{ language: 'zh-cn' }, { language: 'zh-hant' }];
+  return [
+    { language: 'zh-cn' },
+    { language: 'zh-hant' },
+    { language: 'ja' },
+    { language: 'en' },
+    { language: 'es' },
+  ];
 }

--- a/apps/wiki/app/[language]/cup-calculator/components/CupCalculator.tsx
+++ b/apps/wiki/app/[language]/cup-calculator/components/CupCalculator.tsx
@@ -4,6 +4,7 @@ import { useAtom } from 'jotai';
 import { Calculator, Clock, RotateCcw } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
+import { t } from '@/lib/i18n/client';
 import {
   addHistoryRecordAtom,
   historyAtom,
@@ -19,7 +20,11 @@ import {
 } from '../lib/utils';
 import { HistoryPanel } from './HistoryPanel';
 
-export function CupCalculator() {
+interface CupCalculatorProps {
+  language: string;
+}
+
+export function CupCalculator({ language }: CupCalculatorProps) {
   const [measurements, setMeasurements] = useAtom(measurementsAtom);
   const [result, setResult] = useAtom(resultAtom);
   const [, addHistoryRecord] = useAtom(addHistoryRecordAtom);
@@ -27,12 +32,10 @@ export function CupCalculator() {
   const [history] = useAtom(historyAtom);
   const [isCalculating, setIsCalculating] = useState(false);
 
-  // 当所有测量完成时自动计算结果
   useEffect(() => {
     if (isAllMeasurementsComplete(measurements)) {
       setIsCalculating(true);
 
-      // 添加计算动画延迟
       setTimeout(() => {
         const calculatedResult = calculateCupSize(measurements);
         setResult(calculatedResult);
@@ -55,7 +58,7 @@ export function CupCalculator() {
   };
 
   const handleReset = () => {
-    if (confirm('确定要重新开始测量吗？当前数据将被清除。')) {
+    if (confirm(t('cup-restart-confirm', language))) {
       setMeasurements({
         underBustRelaxed: null,
         underBustExhale: null,
@@ -79,18 +82,16 @@ export function CupCalculator() {
     }
   };
 
-  const handleSaveToHistory = () => {
-    if (result && measurements) {
-      addHistoryRecord({
-        measurements,
-        result,
-      });
+  const formatMessage = (res: ReturnType<typeof calculateCupSize>): string => {
+    const raw = t(res.messageKey as never, language) as string;
+    if (res.messageKey === 'cup-msg-result' && res.fullSize) {
+      return raw.replace('{size}', res.fullSize);
     }
+    return raw;
   };
 
   return (
     <div className="space-y-8">
-      {/* 说明文字 */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -98,17 +99,18 @@ export function CupCalculator() {
       >
         <div className="flex items-center gap-3 mb-4">
           <Calculator className="w-5 h-5 text-pink-500" />
-          <h2 className="text-lg font-semibold">测量说明</h2>
+          <h2 className="text-lg font-semibold">
+            {t('cup-instructions-title', language)}
+          </h2>
         </div>
         <p className="text-base-content/80 mb-4">
-          <strong>运算都在您的本地完成，不收集任何数据</strong>
+          <strong>{t('cup-local-only', language)}</strong>
         </p>
         <p className="text-sm text-base-content/70">
-          请准备一根软尺并面对镜子，看得到胸部。按照下面的步骤依次测量并填入数值。
+          {t('cup-prepare', language)}
         </p>
       </motion.div>
 
-      {/* 测量步骤列表 */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -122,14 +124,14 @@ export function CupCalculator() {
             </span>
             <div className="flex-1">
               <span className="text-base-content">
-                请直立，放松，用软尺贴合乳房下缘
+                {t('cup-step1', language)}
                 <span
                   className="mx-1 text-pink-500 font-bold underline"
                   aria-hidden="true"
                 >
                   ⊙⊙
                 </span>
-                ，水平绕身体一圈：
+                {t('cup-step1-suffix', language)}
               </span>
             </div>
             <div className="flex items-center gap-2">
@@ -154,7 +156,9 @@ export function CupCalculator() {
               2.
             </span>
             <div className="flex-1">
-              <span className="text-base-content">请呼气：</span>
+              <span className="text-base-content">
+                {t('cup-step2', language)}
+              </span>
             </div>
             <div className="flex items-center gap-2">
               <input
@@ -179,14 +183,14 @@ export function CupCalculator() {
             </span>
             <div className="flex-1">
               <span className="text-base-content">
-                请直立，放松，用软尺经过乳头
+                {t('cup-step3', language)}
                 <span
                   className="mx-1 text-pink-500 font-bold line-through"
                   aria-hidden="true"
                 >
                   ⊙⊙
                 </span>
-                ，绕身体一圈：
+                {t('cup-step3-suffix', language)}
               </span>
             </div>
             <div className="flex items-center gap-2">
@@ -211,7 +215,9 @@ export function CupCalculator() {
               4.
             </span>
             <div className="flex-1">
-              <span className="text-base-content">请俯身 45 度：</span>
+              <span className="text-base-content">
+                {t('cup-step4', language)}
+              </span>
             </div>
             <div className="flex items-center gap-2">
               <input
@@ -235,7 +241,9 @@ export function CupCalculator() {
               5.
             </span>
             <div className="flex-1">
-              <span className="text-base-content">请鞠躬 90 度：</span>
+              <span className="text-base-content">
+                {t('cup-step5', language)}
+              </span>
             </div>
             <div className="flex items-center gap-2">
               <input
@@ -255,7 +263,6 @@ export function CupCalculator() {
           </li>
         </ol>
 
-        {/* 计算按钮 */}
         <div className="mt-4 md:mt-6 flex justify-center">
           <button
             type="button"
@@ -264,12 +271,11 @@ export function CupCalculator() {
             disabled={!isAllMeasurementsComplete(measurements)}
           >
             <Calculator className="w-4 h-4" />
-            计算罩杯尺寸
+            {t('cup-calculate', language)}
           </button>
         </div>
       </motion.div>
 
-      {/* 结果显示 */}
       {result && (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -281,7 +287,9 @@ export function CupCalculator() {
           }`}
         >
           <div className="text-center">
-            <h3 className="text-xl font-semibold mb-3 md:mb-4">计算结果</h3>
+            <h3 className="text-xl font-semibold mb-3 md:mb-4">
+              {t('cup-result-title', language)}
+            </h3>
             <div
               className={`text-2xl font-bold ${
                 result.isValid
@@ -289,17 +297,19 @@ export function CupCalculator() {
                   : 'text-yellow-600 dark:text-yellow-400'
               }`}
             >
-              {result.message}
+              {formatMessage(result)}
             </div>
 
             {result.isValid && result.fullSize && (
               <div className="mt-4 text-sm text-base-content/70">
-                胸下围：{result.underBust?.toFixed(1)} cm | 罩杯差值：
-                {result.cupDifference?.toFixed(1)} cm | 罩杯：{result.cupSize}
+                {t('cup-result-underbust', language)}：
+                {result.underBust?.toFixed(1)} cm |{' '}
+                {t('cup-result-cup-difference', language)}：
+                {result.cupDifference?.toFixed(1)} cm |{' '}
+                {t('cup-result-cup', language)}：{result.cupSize}
               </div>
             )}
 
-            {/* 欧洲尺码标准 */}
             {result.isValid &&
               result.underBust &&
               result.cupDifference &&
@@ -307,12 +317,13 @@ export function CupCalculator() {
                 const internationalSizes = calculateInternationalSizes(
                   result.underBust,
                   result.cupDifference,
+                  t('cup-eu-below-aa', language) as string,
                 );
                 return (
                   internationalSizes && (
                     <div className="mt-6 pt-4 border-t border-base-300/30">
                       <h4 className="text-sm font-medium text-base-content/80 mb-3 text-center">
-                        欧洲尺码标准
+                        {t('cup-eu-standard', language)}
                       </h4>
                       <div className="text-center text-sm text-base-content/70">
                         <span className="font-mono text-base font-semibold">
@@ -327,7 +338,6 @@ export function CupCalculator() {
         </motion.div>
       )}
 
-      {/* 功能按钮 */}
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -340,7 +350,7 @@ export function CupCalculator() {
           className="btn btn-outline gap-2"
         >
           <Clock className="w-4 h-4" />
-          查看历史记录
+          {t('cup-history', language)}
           {history.length > 0 && (
             <span className="badge badge-primary badge-sm">
               {history.length}
@@ -353,12 +363,11 @@ export function CupCalculator() {
           className="btn btn-outline gap-2 text-warning hover:bg-warning/10"
         >
           <RotateCcw className="w-4 h-4" />
-          重新开始
+          {t('cup-restart', language)}
         </button>
       </motion.div>
 
-      {/* 历史记录面板 */}
-      <HistoryPanel />
+      <HistoryPanel language={language} />
     </div>
   );
 }

--- a/apps/wiki/app/[language]/cup-calculator/components/HistoryPanel.tsx
+++ b/apps/wiki/app/[language]/cup-calculator/components/HistoryPanel.tsx
@@ -4,11 +4,16 @@ import { useAtom } from 'jotai';
 import { Check, Clock, Copy, Trash2, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
+import { t } from '@/lib/i18n/client';
 import { clearHistoryAtom, historyAtom, showHistoryAtom } from '../lib/atoms';
 import type { HistoryRecord } from '../lib/types';
 import { formatTimestamp } from '../lib/utils';
 
-export function HistoryPanel() {
+interface HistoryPanelProps {
+  language: string;
+}
+
+export function HistoryPanel({ language }: HistoryPanelProps) {
   const [history] = useAtom(historyAtom);
   const [, clearHistory] = useAtom(clearHistoryAtom);
   const [showHistory, setShowHistory] = useAtom(showHistoryAtom);
@@ -22,17 +27,21 @@ export function HistoryPanel() {
       setCopiedId(record.id);
       setTimeout(() => setCopiedId(null), 2000);
     } catch (err) {
-      console.error('复制失败:', err);
+      console.error('Copy failed:', err);
     }
   };
 
   const handleClearHistory = () => {
-    if (confirm('确定要清除所有历史记录吗？此操作不可撤销。')) {
+    if (confirm(t('cup-clear-confirm', language))) {
       clearHistory();
     }
   };
 
   if (!showHistory) return null;
+
+  const recordCountText = (
+    t('cup-history-records', language) as string
+  ).replace('{count}', history.length.toString());
 
   return (
     <AnimatePresence>
@@ -51,17 +60,16 @@ export function HistoryPanel() {
           className="bg-base-100 rounded-xl shadow-2xl w-full max-w-4xl max-h-[80vh] overflow-hidden"
           onClick={(e) => e.stopPropagation()}
         >
-          {/* 头部 */}
           <div className="bg-gradient-to-r from-pink-50 to-purple-50 dark:from-pink-950/20 dark:to-purple-950/20 p-6 border-b border-base-300/30">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <Clock className="w-6 h-6 text-pink-500" />
                 <div>
                   <h2 className="text-xl font-semibold text-base-content">
-                    测量历史
+                    {t('cup-history-title', language)}
                   </h2>
                   <p className="text-sm text-base-content/60">
-                    共 {history.length} 条记录，数据仅存储在浏览器本地
+                    {recordCountText}
                   </p>
                 </div>
               </div>
@@ -73,7 +81,7 @@ export function HistoryPanel() {
                     className="btn btn-ghost btn-sm gap-2 text-error hover:bg-error/10"
                   >
                     <Trash2 className="w-4 h-4" />
-                    清空
+                    {t('cup-history-clear', language)}
                   </button>
                 )}
                 <button
@@ -87,16 +95,15 @@ export function HistoryPanel() {
             </div>
           </div>
 
-          {/* 内容区域 */}
           <div className="overflow-y-auto max-h-[calc(80vh-120px)]">
             {history.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-12 text-center">
                 <Clock className="w-16 h-16 text-base-content/30 mb-4" />
                 <h3 className="text-lg font-medium text-base-content/60 mb-2">
-                  暂无历史记录
+                  {t('cup-history-empty', language)}
                 </h3>
                 <p className="text-sm text-base-content/40">
-                  完成测量后，结果会自动保存到这里
+                  {t('cup-history-empty-hint', language)}
                 </p>
               </div>
             ) : (
@@ -112,7 +119,7 @@ export function HistoryPanel() {
                     <div className="flex items-start justify-between mb-3">
                       <div>
                         <div className="text-sm text-base-content/60">
-                          {formatTimestamp(record.timestamp)}
+                          {formatTimestamp(record.timestamp, language)}
                         </div>
                         {record.result.isValid && record.result.fullSize && (
                           <div className="text-lg font-semibold text-base-content mt-1">
@@ -129,22 +136,23 @@ export function HistoryPanel() {
                           {copiedId === record.id ? (
                             <>
                               <Check className="w-3 h-3" />
-                              已复制
+                              {t('cup-history-copied', language)}
                             </>
                           ) : (
                             <>
                               <Copy className="w-3 h-3" />
-                              复制
+                              {t('cup-history-copy', language)}
                             </>
                           )}
                         </button>
                       )}
                     </div>
 
-                    {/* 测量数据 */}
                     <div className="grid grid-cols-2 md:grid-cols-5 gap-2 text-xs">
                       <div className="bg-white/50 dark:bg-black/20 rounded p-2">
-                        <div className="text-base-content/60">胸下围(放松)</div>
+                        <div className="text-base-content/60">
+                          {t('cup-meas-underbust-relaxed', language)}
+                        </div>
                         <div className="font-mono">
                           {record.measurements.underBustRelaxed?.toFixed(1) ||
                             '—'}{' '}
@@ -152,7 +160,9 @@ export function HistoryPanel() {
                         </div>
                       </div>
                       <div className="bg-white/50 dark:bg-black/20 rounded p-2">
-                        <div className="text-base-content/60">胸下围(呼气)</div>
+                        <div className="text-base-content/60">
+                          {t('cup-meas-underbust-exhale', language)}
+                        </div>
                         <div className="font-mono">
                           {record.measurements.underBustExhale?.toFixed(1) ||
                             '—'}{' '}
@@ -160,33 +170,38 @@ export function HistoryPanel() {
                         </div>
                       </div>
                       <div className="bg-white/50 dark:bg-black/20 rounded p-2">
-                        <div className="text-base-content/60">胸围(放松)</div>
+                        <div className="text-base-content/60">
+                          {t('cup-meas-bust-relaxed', language)}
+                        </div>
                         <div className="font-mono">
                           {record.measurements.bustRelaxed?.toFixed(1) || '—'}{' '}
                           cm
                         </div>
                       </div>
                       <div className="bg-white/50 dark:bg-black/20 rounded p-2">
-                        <div className="text-base-content/60">胸围(45°)</div>
+                        <div className="text-base-content/60">
+                          {t('cup-meas-bust-bend45', language)}
+                        </div>
                         <div className="font-mono">
                           {record.measurements.bustBend45?.toFixed(1) || '—'} cm
                         </div>
                       </div>
                       <div className="bg-white/50 dark:bg-black/20 rounded p-2">
-                        <div className="text-base-content/60">胸围(90°)</div>
+                        <div className="text-base-content/60">
+                          {t('cup-meas-bust-bend90', language)}
+                        </div>
                         <div className="font-mono">
                           {record.measurements.bustBend90?.toFixed(1) || '—'} cm
                         </div>
                       </div>
                     </div>
 
-                    {/* 计算结果 */}
                     {record.result.isValid && (
                       <div className="mt-3 pt-3 border-t border-base-300/30">
                         <div className="grid grid-cols-3 gap-2 text-xs">
                           <div>
                             <span className="text-base-content/60">
-                              胸下围：
+                              {t('cup-result-underbust', language)}：
                             </span>
                             <span className="font-mono">
                               {record.result.underBust?.toFixed(1)} cm
@@ -194,26 +209,21 @@ export function HistoryPanel() {
                           </div>
                           <div>
                             <span className="text-base-content/60">
-                              罩杯差值：
+                              {t('cup-result-cup-difference', language)}：
                             </span>
                             <span className="font-mono">
                               {record.result.cupDifference?.toFixed(1)} cm
                             </span>
                           </div>
                           <div>
-                            <span className="text-base-content/60">罩杯：</span>
+                            <span className="text-base-content/60">
+                              {t('cup-result-cup', language)}：
+                            </span>
                             <span className="font-mono">
                               {record.result.cupSize}
                             </span>
                           </div>
                         </div>
-                      </div>
-                    )}
-
-                    {/* 特殊消息 */}
-                    {!record.result.fullSize && record.result.message && (
-                      <div className="mt-3 text-sm text-base-content/70 italic">
-                        {record.result.message}
                       </div>
                     )}
                   </motion.div>

--- a/apps/wiki/app/[language]/cup-calculator/lib/constants.ts
+++ b/apps/wiki/app/[language]/cup-calculator/lib/constants.ts
@@ -1,16 +1,16 @@
 import type { CupSizeInfo } from './types';
 
 export const CUP_SIZES: CupSizeInfo[] = [
-  { threshold: 4.999999, size: 'AA以下', message: '小妹妹你还不需要穿内衣哦' }, // < 5
-  { threshold: 7.5, size: 'AA', message: 'AA，买少女小背心去吧' },
-  { threshold: 10, size: 'A', message: '' },
-  { threshold: 12.5, size: 'B', message: '' },
-  { threshold: 15, size: 'C', message: '' },
-  { threshold: 17.5, size: 'D', message: '' },
-  { threshold: 20, size: 'E', message: '' },
+  { threshold: 4.999999, size: 'AA-', messageKey: 'cup-msg-too-small' }, // < 5
+  { threshold: 7.5, size: 'AA', messageKey: 'cup-msg-aa' },
+  { threshold: 10, size: 'A', messageKey: '' },
+  { threshold: 12.5, size: 'B', messageKey: '' },
+  { threshold: 15, size: 'C', messageKey: '' },
+  { threshold: 17.5, size: 'D', messageKey: '' },
+  { threshold: 20, size: 'E', messageKey: '' },
   {
     threshold: Number.POSITIVE_INFINITY,
     size: 'E+',
-    message: '你胸大你说了算（罩杯超出 MtF.wiki 预设）',
+    messageKey: 'cup-msg-too-large',
   },
 ];

--- a/apps/wiki/app/[language]/cup-calculator/lib/types.ts
+++ b/apps/wiki/app/[language]/cup-calculator/lib/types.ts
@@ -8,12 +8,12 @@ export interface MeasurementData {
 
 export interface CupResult {
   isValid: boolean;
-  underBust: number | null; // 计算得出的胸下围
-  cupDifference: number | null; // 罩杯差值
-  cupSize: string | null; // 罩杯大小
-  bandSize: number | null; // 胸围尺寸
-  fullSize: string | null; // 完整尺寸 (如 "75B")
-  message: string; // 结果消息
+  underBust: number | null;
+  cupDifference: number | null;
+  cupSize: string | null;
+  bandSize: number | null;
+  fullSize: string | null;
+  messageKey: string;
 }
 
 export interface HistoryRecord {
@@ -32,7 +32,7 @@ export interface CalculatorState {
 export interface CupSizeInfo {
   threshold: number;
   size: string;
-  message: string;
+  messageKey: string;
 }
 
 export interface InternationalBraSize {

--- a/apps/wiki/app/[language]/cup-calculator/lib/utils.ts
+++ b/apps/wiki/app/[language]/cup-calculator/lib/utils.ts
@@ -1,9 +1,6 @@
 import { CUP_SIZES } from './constants';
 import type { CupResult, InternationalBraSize, MeasurementData } from './types';
 
-/**
- * 计算罩杯尺寸
- */
 export function calculateCupSize(measurements: MeasurementData): CupResult {
   const {
     underBustRelaxed,
@@ -13,7 +10,6 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
     bustBend90,
   } = measurements;
 
-  // 检查所有必需的测量数据是否存在
   if (
     underBustRelaxed === null ||
     underBustExhale === null ||
@@ -28,11 +24,10 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
       cupSize: null,
       bandSize: null,
       fullSize: null,
-      message: '请完成所有测量步骤',
+      messageKey: 'cup-msg-incomplete',
     };
   }
 
-  // 检查数据有效性
   if (
     Number.isNaN(underBustRelaxed) ||
     Number.isNaN(underBustExhale) ||
@@ -52,11 +47,10 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
       cupSize: null,
       bandSize: null,
       fullSize: null,
-      message: '数值错误，请检查输入的数据',
+      messageKey: 'cup-msg-invalid',
     };
   }
 
-  // 按照原算法计算
   const underBust = (underBustRelaxed + underBustExhale) / 2;
   const cupDifference = (bustRelaxed + bustBend45 + bustBend90) / 3 - underBust;
 
@@ -68,14 +62,12 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
       cupSize: null,
       bandSize: null,
       fullSize: null,
-      message: '请检查测量数据',
+      messageKey: 'cup-msg-recheck',
     };
   }
 
-  // 按照原版逻辑判断罩杯尺寸（使用 <= 判断）
   let cupInfo = null;
 
-  // 循环查找对应的罩杯尺寸
   for (let i = 0; i < CUP_SIZES.length; i++) {
     if (cupDifference <= CUP_SIZES[i].threshold) {
       cupInfo = CUP_SIZES[i];
@@ -83,7 +75,6 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
     }
   }
 
-  // 理论上不应该出现找不到的情况，因为最后一个threshold是Infinity
   if (!cupInfo) {
     return {
       isValid: false,
@@ -92,16 +83,14 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
       cupSize: null,
       bandSize: null,
       fullSize: null,
-      message: '计算结果超出预设范围',
+      messageKey: 'cup-msg-out-of-range',
     };
   }
 
-  // 计算胸围尺寸（向上取整到最近的5的倍数）
   const bandSize = Math.ceil(underBust / 5) * 5;
   const fullSize = `${bandSize}${cupInfo.size}`;
 
-  // 如果有特殊消息，直接返回
-  if (cupInfo.message) {
+  if (cupInfo.messageKey) {
     return {
       isValid: true,
       underBust,
@@ -109,7 +98,7 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
       cupSize: cupInfo.size,
       bandSize,
       fullSize,
-      message: cupInfo.message,
+      messageKey: cupInfo.messageKey,
     };
   }
 
@@ -120,21 +109,15 @@ export function calculateCupSize(measurements: MeasurementData): CupResult {
     cupSize: cupInfo.size,
     bandSize,
     fullSize,
-    message: `您的内衣尺寸是：${fullSize}`,
+    messageKey: 'cup-msg-result',
   };
 }
 
-/**
- * 格式化数值显示
- */
 export function formatValue(value: number | null): string {
   if (value === null) return '—';
   return value.toFixed(1);
 }
 
-/**
- * 验证输入值
- */
 export function validateInput(value: string): {
   isValid: boolean;
   numValue: number | null;
@@ -151,9 +134,6 @@ export function validateInput(value: string): {
   return { isValid: true, numValue };
 }
 
-/**
- * 检查是否所有测量都已完成
- */
 export function isAllMeasurementsComplete(
   measurements: MeasurementData,
 ): boolean {
@@ -162,12 +142,17 @@ export function isAllMeasurementsComplete(
   );
 }
 
-/**
- * 格式化时间戳
- */
-export function formatTimestamp(timestamp: number): string {
+const LOCALE_MAP: Record<string, string> = {
+  'zh-cn': 'zh-CN',
+  'zh-hant': 'zh-TW',
+  ja: 'ja-JP',
+  en: 'en-US',
+  es: 'es-ES',
+};
+
+export function formatTimestamp(timestamp: number, language = 'zh-cn'): string {
   const date = new Date(timestamp);
-  return date.toLocaleString('zh-CN', {
+  return date.toLocaleString(LOCALE_MAP[language] || 'en-US', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -176,22 +161,17 @@ export function formatTimestamp(timestamp: number): string {
   });
 }
 
-/**
- * 根据胸下围和罩杯差值计算国际尺码标准
- * 基于维基百科的胸罩尺码标准，直接从测量数据计算各国尺码
- * 参考: https://en.wikipedia.org/wiki/Bra_size
- */
 export function calculateInternationalSizes(
   underBust: number,
   cupDifference: number,
+  belowAALabel = 'AA-',
 ): InternationalBraSize | null {
   if (!underBust || !cupDifference || underBust <= 0 || cupDifference <= 0) {
     return null;
   }
 
-  // 欧盟标准罩杯字母 (不同的差值范围)
   let europeCupLetter: string;
-  if (cupDifference < 10) europeCupLetter = 'AA以下';
+  if (cupDifference < 10) europeCupLetter = belowAALabel;
   else if (cupDifference <= 12) europeCupLetter = 'AA';
   else if (cupDifference <= 14) europeCupLetter = 'A';
   else if (cupDifference <= 16) europeCupLetter = 'B';

--- a/apps/wiki/app/[language]/cup-calculator/page.tsx
+++ b/apps/wiki/app/[language]/cup-calculator/page.tsx
@@ -1,5 +1,6 @@
-import SuggestionBox from '@/components/SuggestionBox';
 import { Ruler, Shield } from 'lucide-react';
+import SuggestionBox from '@/components/SuggestionBox';
+import { t } from '@/lib/i18n/client';
 import { CupCalculator } from './components/CupCalculator';
 
 export async function generateMetadata({
@@ -9,87 +10,58 @@ export async function generateMetadata({
 }) {
   const { language } = await params;
   return {
-    title: '罩杯计算器 - MtF.wiki',
+    title: `${t('cup-page-title', language)} - MtF.wiki`,
   };
 }
 
-export default function CupCalculatorPage() {
+export default async function CupCalculatorPage({
+  params,
+}: {
+  params: Promise<{ language: string }>;
+}) {
+  const { language } = await params;
   return (
     <div className="container mx-auto px-4 py-6 md:py-8">
       <div className="max-w-4xl mx-auto">
-        {/* 页面头部 */}
         <header className="text-center mb-6 md:mb-8">
           <div className="flex items-center justify-center gap-4 mb-4">
             <div className="w-12 h-12 bg-gradient-to-br from-pink-500 to-purple-500 rounded-xl flex items-center justify-center">
               <Ruler className="w-6 h-6 text-white" />
             </div>
-            <h1 className="text-4xl font-bold text-base-content">罩杯计算器</h1>
+            <h1 className="text-4xl font-bold text-base-content">
+              {t('cup-page-title', language)}
+            </h1>
           </div>
           <p className="text-base-content/70 text-lg max-w-2xl mx-auto">
-            {/* description */}
+            {t('cup-page-description', language)}
           </p>
         </header>
 
-        {/* 使用说明
-        <div className="bg-gradient-to-br from-pink-50 to-purple-50 dark:from-pink-950/20 dark:to-purple-950/20 rounded-xl p-6 mb-8 border border-pink-200/30 dark:border-pink-800/30">
-          <h2 className="text-xl font-semibold text-base-content mb-4 flex items-center gap-2">
-            <Heart className="w-5 h-5 text-pink-500" />
-            使用说明
-          </h2>
-          <div className="grid md:grid-cols-2 gap-6">
-            <div>
-              <h3 className="font-medium text-base-content mb-2">测量准备</h3>
-              <ul className="text-sm text-base-content/70 space-y-1">
-                <li>• 准备一根软尺（布尺）</li>
-                <li>• 面对镜子，确保能看到胸部</li>
-                <li>• 穿着合适的内衣或不穿内衣</li>
-                <li>• 保持自然站立姿势</li>
-              </ul>
-            </div>
-            <div>
-              <h3 className="font-medium text-base-content mb-2">测量要点</h3>
-              <ul className="text-sm text-base-content/70 space-y-1">
-                <li>• 软尺要贴合身体，不要过紧或过松</li>
-                <li>• 保持水平，避免倾斜</li>
-                <li>• 按照指引完成5个步骤的测量</li>
-                <li>• 每个数值都很重要，请认真测量</li>
-              </ul>
-            </div>
-          </div>
-        </div> */}
+        <CupCalculator language={language} />
 
-        {/* 主要计算器 */}
-        <CupCalculator />
-
-        {/* 页面底部信息 */}
         <footer className="mt-8 md:mt-12 p-4 md:p-6 bg-base-200/50 rounded-xl">
           <div className="text-sm text-base-content/60 space-y-3">
             <div className="flex items-start gap-3">
               <Shield className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
               <div>
-                <p className="font-medium text-base-content mb-1">隐私保护</p>
-                <p>
-                  所有测量数据和计算结果仅存储在您的浏览器本地，不会上传到服务器。
-                  您可以随时清除历史记录，保护个人隐私。
+                <p className="font-medium text-base-content mb-1">
+                  {t('cup-privacy-title', language)}
                 </p>
+                <p>{t('cup-privacy-text', language)}</p>
               </div>
             </div>
 
             <div className="border-t border-base-300/30 pt-3">
               <p>
-                <strong>免责声明：</strong>
-                计算结果仅供参考。
-                由于个体差异和品牌差异，建议在购买内衣时进行试穿确认。
-                如有特殊需求，请咨询商家或专业人士。
+                <strong>{t('cup-disclaimer-title', language)}：</strong>
+                {t('cup-disclaimer-text', language)}
               </p>
             </div>
 
             <div className="border-t border-base-300/30 pt-3">
               <p>
-                <strong>算法说明：</strong>
-                胸下围 = (放松测量 + 呼气测量) ÷ 2， 罩杯差值 = (胸围放松 +
-                胸围45° + 胸围90°) ÷ 3 - 胸下围， 最终尺寸 =
-                胸下围(向上取整到5的倍数) + 对应罩杯字母
+                <strong>{t('cup-algorithm-title', language)}：</strong>
+                {t('cup-algorithm-text', language)}
               </p>
             </div>
           </div>
@@ -103,5 +75,11 @@ export default function CupCalculatorPage() {
 }
 
 export async function generateStaticParams() {
-  return [{ language: 'zh-cn' }];
+  return [
+    { language: 'zh-cn' },
+    { language: 'zh-hant' },
+    { language: 'ja' },
+    { language: 'en' },
+    { language: 'es' },
+  ];
 }

--- a/apps/wiki/lib/i18n/translations/translations.json
+++ b/apps/wiki/lib/i18n/translations/translations.json
@@ -159,5 +159,803 @@
     "ja": "現在のフォント",
     "es": "Fuente actual",
     "en": "Current Font"
+  },
+  "cup-page-title": {
+    "zh-cn": "罩杯计算器",
+    "zh-hant": "胸圍計算",
+    "ja": "ブラジャーサイズ計算",
+    "es": "Calculadora de talla de sujetador",
+    "en": "Cup Calculator"
+  },
+  "cup-page-description": {
+    "zh-cn": "通过软尺测量计算合身的胸罩尺寸",
+    "zh-hant": "透過軟尺測量計算合身的胸罩尺寸",
+    "ja": "メジャーで測定して合うブラジャーのサイズを計算",
+    "es": "Calcula tu talla de sujetador con una cinta métrica",
+    "en": "Calculate your bra size using a measuring tape"
+  },
+  "cup-instructions-title": {
+    "zh-cn": "测量说明",
+    "zh-hant": "測量說明",
+    "ja": "測定の説明",
+    "es": "Instrucciones de medición",
+    "en": "Measurement Instructions"
+  },
+  "cup-local-only": {
+    "zh-cn": "运算都在您的本地完成，不收集任何数据",
+    "zh-hant": "計算會在你的電腦上完成，不會向伺服器回傳任何資料",
+    "ja": "計算はすべてローカルで行われ、データは一切収集されません",
+    "es": "Todos los cálculos se realizan localmente, no se recopilan datos",
+    "en": "All calculations run locally; no data is collected"
+  },
+  "cup-prepare": {
+    "zh-cn": "请准备一根软尺并面对镜子，看得到胸部。按照下面的步骤依次测量并填入数值。",
+    "zh-hant": "請準備一條軟尺面向鏡子，能看見胸部。依下列步驟依序測量並填入數值。",
+    "ja": "メジャーを用意し、鏡の前で胸が見える状態にしてください。以下の手順で順に測定し数値を入力してください。",
+    "es": "Prepara una cinta métrica frente a un espejo donde puedas ver tu pecho. Sigue los pasos a continuación e ingresa los valores.",
+    "en": "Have a soft measuring tape ready and stand facing a mirror so you can see your chest. Follow the steps below and enter each measurement."
+  },
+  "cup-step1": {
+    "zh-cn": "请直立，放松，用软尺贴合乳房下缘",
+    "zh-hant": "請站直、放鬆，將軟尺貼合乳房下緣",
+    "ja": "まっすぐ立ち、リラックスした状態でメジャーを乳房の下縁に当てて",
+    "es": "De pie, relajada, coloca la cinta justo debajo del pecho",
+    "en": "Stand upright and relaxed, place the tape against the underbust"
+  },
+  "cup-step1-suffix": {
+    "zh-cn": "，水平绕身体一圈：",
+    "zh-hant": "，水平繞身體一圈：",
+    "ja": "、水平に体に一周巻きます：",
+    "es": " y rodea el cuerpo horizontalmente:",
+    "en": " and wrap horizontally around the body:"
+  },
+  "cup-step2": {
+    "zh-cn": "请呼气：",
+    "zh-hant": "請呼氣：",
+    "ja": "息を吐いた状態で：",
+    "es": "Exhala:",
+    "en": "Now exhale:"
+  },
+  "cup-step3": {
+    "zh-cn": "请直立，放松，用软尺经过乳头",
+    "zh-hant": "請站直、放鬆，將軟尺經乳頭",
+    "ja": "まっすぐ立ち、リラックスした状態でメジャーを乳頭の位置に当てて",
+    "es": "De pie, relajada, pasa la cinta por los pezones",
+    "en": "Stand upright and relaxed, run the tape across the nipples"
+  },
+  "cup-step3-suffix": {
+    "zh-cn": "，绕身体一圈：",
+    "zh-hant": "，繞身體一圈：",
+    "ja": "、体に一周巻きます：",
+    "es": " rodeando el cuerpo:",
+    "en": " and wrap around the body:"
+  },
+  "cup-step4": {
+    "zh-cn": "请俯身 45 度：",
+    "zh-hant": "請俯身 45 度：",
+    "ja": "45度前傾した姿勢で：",
+    "es": "Inclínate 45 grados:",
+    "en": "Bend forward 45 degrees:"
+  },
+  "cup-step5": {
+    "zh-cn": "请鞠躬 90 度：",
+    "zh-hant": "請鞠躬 90 度：",
+    "ja": "90度お辞儀した姿勢で：",
+    "es": "Inclínate 90 grados:",
+    "en": "Bend forward 90 degrees:"
+  },
+  "cup-calculate": {
+    "zh-cn": "计算罩杯尺寸",
+    "zh-hant": "計算罩杯尺寸",
+    "ja": "サイズを計算",
+    "es": "Calcular talla",
+    "en": "Calculate Cup Size"
+  },
+  "cup-result-title": {
+    "zh-cn": "计算结果",
+    "zh-hant": "計算結果",
+    "ja": "計算結果",
+    "es": "Resultado",
+    "en": "Result"
+  },
+  "cup-result-underbust": {
+    "zh-cn": "胸下围",
+    "zh-hant": "下胸圍",
+    "ja": "アンダーバスト",
+    "es": "Bajo busto",
+    "en": "Underbust"
+  },
+  "cup-result-cup-difference": {
+    "zh-cn": "罩杯差值",
+    "zh-hant": "罩杯差值",
+    "ja": "カップ差",
+    "es": "Diferencia de copa",
+    "en": "Cup Difference"
+  },
+  "cup-result-cup": {
+    "zh-cn": "罩杯",
+    "zh-hant": "罩杯",
+    "ja": "カップ",
+    "es": "Copa",
+    "en": "Cup"
+  },
+  "cup-eu-standard": {
+    "zh-cn": "欧洲尺码标准",
+    "zh-hant": "歐洲尺碼標準",
+    "ja": "欧州サイズ規格",
+    "es": "Estándar europeo",
+    "en": "European Size Standard"
+  },
+  "cup-history": {
+    "zh-cn": "查看历史记录",
+    "zh-hant": "查看歷史記錄",
+    "ja": "履歴を見る",
+    "es": "Ver historial",
+    "en": "View History"
+  },
+  "cup-restart": {
+    "zh-cn": "重新开始",
+    "zh-hant": "重新開始",
+    "ja": "やり直す",
+    "es": "Reiniciar",
+    "en": "Restart"
+  },
+  "cup-restart-confirm": {
+    "zh-cn": "确定要重新开始测量吗？当前数据将被清除。",
+    "zh-hant": "確定要重新開始測量嗎？當前資料將被清除。",
+    "ja": "本当に最初から測定し直しますか？現在の入力は消去されます。",
+    "es": "¿Seguro que quieres reiniciar? Los datos actuales se borrarán.",
+    "en": "Restart measurement? Current data will be cleared."
+  },
+  "cup-clear-confirm": {
+    "zh-cn": "确定要清除所有历史记录吗？此操作不可撤销。",
+    "zh-hant": "確定要清除所有歷史記錄嗎？此操作不可撤銷。",
+    "ja": "すべての履歴を削除しますか？この操作は取り消せません。",
+    "es": "¿Borrar todo el historial? Esta acción no se puede deshacer.",
+    "en": "Clear all history? This cannot be undone."
+  },
+  "cup-history-title": {
+    "zh-cn": "测量历史",
+    "zh-hant": "測量歷史",
+    "ja": "測定履歴",
+    "es": "Historial de mediciones",
+    "en": "Measurement History"
+  },
+  "cup-history-records": {
+    "zh-cn": "共 {count} 条记录，数据仅存储在浏览器本地",
+    "zh-hant": "共 {count} 筆記錄，資料僅儲存在瀏覽器本機",
+    "ja": "全 {count} 件、データはブラウザにのみ保存されます",
+    "es": "{count} registros, los datos solo se guardan localmente",
+    "en": "{count} records, stored only in your browser"
+  },
+  "cup-history-empty": {
+    "zh-cn": "暂无历史记录",
+    "zh-hant": "尚無歷史記錄",
+    "ja": "履歴がありません",
+    "es": "Sin historial",
+    "en": "No history yet"
+  },
+  "cup-history-empty-hint": {
+    "zh-cn": "完成测量后，结果会自动保存到这里",
+    "zh-hant": "完成測量後，結果會自動儲存到這裡",
+    "ja": "測定が完了すると、ここに自動的に保存されます",
+    "es": "Tus resultados aparecerán aquí al completar una medición",
+    "en": "Your results will appear here after a measurement"
+  },
+  "cup-history-clear": {
+    "zh-cn": "清空",
+    "zh-hant": "清空",
+    "ja": "クリア",
+    "es": "Borrar",
+    "en": "Clear"
+  },
+  "cup-history-copied": {
+    "zh-cn": "已复制",
+    "zh-hant": "已複製",
+    "ja": "コピー済み",
+    "es": "Copiado",
+    "en": "Copied"
+  },
+  "cup-history-copy": {
+    "zh-cn": "复制",
+    "zh-hant": "複製",
+    "ja": "コピー",
+    "es": "Copiar",
+    "en": "Copy"
+  },
+  "cup-meas-underbust-relaxed": {
+    "zh-cn": "胸下围(放松)",
+    "zh-hant": "下胸圍 (放鬆)",
+    "ja": "アンダーバスト (リラックス)",
+    "es": "Bajo busto (relajado)",
+    "en": "Underbust (relaxed)"
+  },
+  "cup-meas-underbust-exhale": {
+    "zh-cn": "胸下围(呼气)",
+    "zh-hant": "下胸圍 (呼氣)",
+    "ja": "アンダーバスト (呼気)",
+    "es": "Bajo busto (exhalación)",
+    "en": "Underbust (exhale)"
+  },
+  "cup-meas-bust-relaxed": {
+    "zh-cn": "胸围(放松)",
+    "zh-hant": "胸圍 (放鬆)",
+    "ja": "バスト (リラックス)",
+    "es": "Busto (relajado)",
+    "en": "Bust (relaxed)"
+  },
+  "cup-meas-bust-bend45": {
+    "zh-cn": "胸围(45°)",
+    "zh-hant": "胸圍 (45°)",
+    "ja": "バスト (45°)",
+    "es": "Busto (45°)",
+    "en": "Bust (45°)"
+  },
+  "cup-meas-bust-bend90": {
+    "zh-cn": "胸围(90°)",
+    "zh-hant": "胸圍 (90°)",
+    "ja": "バスト (90°)",
+    "es": "Busto (90°)",
+    "en": "Bust (90°)"
+  },
+  "cup-msg-incomplete": {
+    "zh-cn": "请完成所有测量步骤",
+    "zh-hant": "請完成所有測量步驟",
+    "ja": "すべての測定を完了してください",
+    "es": "Completa todas las mediciones",
+    "en": "Please complete all measurement steps"
+  },
+  "cup-msg-invalid": {
+    "zh-cn": "数值错误，请检查输入的数据",
+    "zh-hant": "數值有誤，請檢查輸入的資料",
+    "ja": "数値が不正です。入力をご確認ください",
+    "es": "Valores incorrectos, revisa los datos",
+    "en": "Invalid values, please check your input"
+  },
+  "cup-msg-recheck": {
+    "zh-cn": "请检查测量数据",
+    "zh-hant": "請檢查測量資料",
+    "ja": "測定データを確認してください",
+    "es": "Revisa las mediciones",
+    "en": "Please verify the measurements"
+  },
+  "cup-msg-out-of-range": {
+    "zh-cn": "计算结果超出预设范围",
+    "zh-hant": "計算結果超出預設範圍",
+    "ja": "計算結果がプリセット範囲を超えています",
+    "es": "El resultado supera el rango previsto",
+    "en": "Result is out of preset range"
+  },
+  "cup-msg-too-small": {
+    "zh-cn": "小妹妹你还不需要穿内衣哦",
+    "zh-hant": "小妹妹妳還不需要穿內衣唷",
+    "ja": "まだブラジャーは必要ないようです",
+    "es": "Aún no necesitas usar sujetador",
+    "en": "You don't need a bra yet"
+  },
+  "cup-msg-aa": {
+    "zh-cn": "AA，买少女小背心去吧",
+    "zh-hant": "AA，購買少女內衣",
+    "ja": "AA、ジュニア用ブラを選びましょう",
+    "es": "AA, elige un sujetador juvenil",
+    "en": "AA — try a junior camisole"
+  },
+  "cup-msg-too-large": {
+    "zh-cn": "你胸大你说了算（罩杯超出 MtF.wiki 预设）",
+    "zh-hant": "妳胸大妳說了算（罩杯超出 MtF.wiki 預設）",
+    "ja": "規定外のサイズです（MtF.wiki のプリセット範囲外）",
+    "es": "Talla fuera del rango previsto en MtF.wiki",
+    "en": "Cup size exceeds MtF.wiki's preset range"
+  },
+  "cup-msg-result": {
+    "zh-cn": "您的内衣尺寸是：{size}",
+    "zh-hant": "您的內衣尺寸是：{size}",
+    "ja": "あなたのサイズは：{size}",
+    "es": "Tu talla es: {size}",
+    "en": "Your size is: {size}"
+  },
+  "cup-eu-below-aa": {
+    "zh-cn": "AA以下",
+    "zh-hant": "AA以下",
+    "ja": "AA未満",
+    "es": "Menor a AA",
+    "en": "Below AA"
+  },
+  "cup-privacy-title": {
+    "zh-cn": "隐私保护",
+    "zh-hant": "隱私保護",
+    "ja": "プライバシー保護",
+    "es": "Privacidad",
+    "en": "Privacy"
+  },
+  "cup-privacy-text": {
+    "zh-cn": "所有测量数据和计算结果仅存储在您的浏览器本地，不会上传到服务器。您可以随时清除历史记录，保护个人隐私。",
+    "zh-hant": "所有測量資料和計算結果僅儲存在您的瀏覽器本機，不會上傳至伺服器。您可以隨時清除歷史記錄。",
+    "ja": "測定値と計算結果はすべてブラウザのローカルにのみ保存され、サーバーへ送信されることはありません。履歴はいつでも削除できます。",
+    "es": "Todos los datos y resultados se guardan solo en tu navegador, nunca se suben a un servidor. Puedes borrar el historial cuando quieras.",
+    "en": "All measurements and results stay in your browser; nothing is uploaded. You can clear the history at any time."
+  },
+  "cup-disclaimer-title": {
+    "zh-cn": "免责声明",
+    "zh-hant": "免責聲明",
+    "ja": "免責事項",
+    "es": "Aviso legal",
+    "en": "Disclaimer"
+  },
+  "cup-disclaimer-text": {
+    "zh-cn": "计算结果仅供参考。由于个体差异和品牌差异，建议在购买内衣时进行试穿确认。如有特殊需求，请咨询商家或专业人士。",
+    "zh-hant": "計算結果僅供參考。由於個體和品牌差異，建議購買時親自試穿確認。如有特殊需求，請洽詢店家或專業人士。",
+    "ja": "計算結果は参考値です。個人差・ブランド差があるため、購入時に試着して確認することをお勧めします。特別な事情がある場合は店員または専門家にご相談ください。",
+    "es": "Los resultados son orientativos. Dadas las diferencias individuales y entre marcas, prueba la prenda antes de comprarla y consulta a un profesional si lo necesitas.",
+    "en": "Results are for reference only. Because of individual and brand variation, try the garment before purchase, and consult a specialist if needed."
+  },
+  "cup-algorithm-title": {
+    "zh-cn": "算法说明",
+    "zh-hant": "演算法說明",
+    "ja": "アルゴリズム",
+    "es": "Algoritmo",
+    "en": "Algorithm"
+  },
+  "cup-algorithm-text": {
+    "zh-cn": "胸下围 = (放松测量 + 呼气测量) ÷ 2， 罩杯差值 = (胸围放松 + 胸围45° + 胸围90°) ÷ 3 - 胸下围， 最终尺寸 = 胸下围(向上取整到5的倍数) + 对应罩杯字母",
+    "zh-hant": "下胸圍 = (放鬆 + 呼氣) ÷ 2， 罩杯差值 = (放鬆 + 45° + 90°) ÷ 3 - 下胸圍， 最終尺寸 = 下胸圍 (向上取整至 5 的倍數) + 對應罩杯字母",
+    "ja": "アンダーバスト = (リラックス + 呼気) ÷ 2、 カップ差 = (リラックス + 45° + 90°) ÷ 3 − アンダーバスト、 最終サイズ = アンダーバスト (5 単位に切り上げ) + 対応するカップ文字",
+    "es": "Bajo busto = (relajado + exhalación) ÷ 2; diferencia de copa = (busto relajado + 45° + 90°) ÷ 3 − bajo busto; talla final = bajo busto (redondeado al múltiplo de 5) + letra de copa",
+    "en": "Underbust = (relaxed + exhale) ÷ 2; cup difference = (relaxed + 45° + 90°) ÷ 3 − underbust; final size = underbust (rounded up to nearest 5) + corresponding cup letter"
+  },
+  "conv-page-title": {
+    "zh-cn": "激素换算器",
+    "zh-hant": "荷爾蒙換算",
+    "ja": "ホルモン換算",
+    "es": "Conversor de hormonas",
+    "en": "Hormone Unit Converter"
+  },
+  "conv-page-intro": {
+    "zh-cn": "有关单位转换的具体规则，请参见",
+    "zh-hant": "關於單位換算的具體規則，請參見",
+    "ja": "単位換算の詳細については、",
+    "es": "Para los detalles de la conversión de unidades, consulta",
+    "en": "For unit conversion rules, see"
+  },
+  "conv-science-literacy": {
+    "zh-cn": "单位科普",
+    "zh-hant": "單位科普",
+    "ja": "単位の解説",
+    "es": "Guía de unidades",
+    "en": "Unit Guide"
+  },
+  "conv-iu-note": {
+    "zh-cn": "部分医院可能使用 IU（国际单位）作为衡量激素水平的单位，但由于 IU 为医学效价单位，其与质量单位的换算取决于药物种类且可能随时间变化。",
+    "zh-hant": "部分醫院可能使用 IU（國際單位）作為衡量荷爾蒙水平的單位，但由於 IU 為醫學效價單位，其與質量單位的換算取決於藥物種類且可能隨時間變化。",
+    "ja": "病院によってはホルモン値の単位として IU（国際単位）が使われることがありますが、IU は医学的効価の単位であり、質量単位への換算は薬剤や時期により変化します。",
+    "es": "Algunos hospitales usan IU (Unidad Internacional). Como la IU mide potencia farmacológica, su conversión a unidades de masa depende del fármaco y puede cambiar con el tiempo.",
+    "en": "Some hospitals use IU (International Units) for hormone levels. Because IU measures biological potency, its conversion to mass units depends on the drug and can change over time."
+  },
+  "conv-history-note": {
+    "zh-cn": "您的换算历史记录仅存储在浏览器本地，不会上传到服务器。",
+    "zh-hant": "您的換算歷史僅儲存於瀏覽器本機，不會上傳到伺服器。",
+    "ja": "換算履歴はブラウザのローカルにのみ保存され、サーバーには送信されません。",
+    "es": "Tu historial se guarda solo en tu navegador, no se sube a ningún servidor.",
+    "en": "Your conversion history stays in your browser; nothing is uploaded."
+  },
+  "conv-data-storage": {
+    "zh-cn": "数据存储说明",
+    "zh-hant": "資料儲存說明",
+    "ja": "データ保存について",
+    "es": "Almacenamiento",
+    "en": "Storage"
+  },
+  "conv-note-prefix": {
+    "zh-cn": "注意",
+    "zh-hant": "注意",
+    "ja": "注意",
+    "es": "Aviso",
+    "en": "Note"
+  },
+  "conv-iu-detail-link": {
+    "zh-cn": "单位科普 - 国际单位（IU）",
+    "zh-hant": "單位科普 - 國際單位（IU）",
+    "ja": "単位の解説 - 国際単位 (IU)",
+    "es": "Guía de unidades — Unidad Internacional (IU)",
+    "en": "Unit Guide — International Units (IU)"
+  },
+  "conv-iu-link-text": {
+    "zh-cn": "IU（国际单位）",
+    "zh-hant": "IU（國際單位）",
+    "ja": "IU（国際単位）",
+    "es": "IU (Unidad Internacional)",
+    "en": "IU (International Unit)"
+  },
+  "conv-detail-see": {
+    "zh-cn": "详见",
+    "zh-hant": "詳見",
+    "ja": "詳細：",
+    "es": "Ver más:",
+    "en": "See"
+  },
+  "conv-select-hormone": {
+    "zh-cn": "选择激素类型",
+    "zh-hant": "選擇荷爾蒙類型",
+    "ja": "ホルモンを選択",
+    "es": "Elegir hormona",
+    "en": "Select Hormone"
+  },
+  "conv-units-count": {
+    "zh-cn": "{count} 种单位",
+    "zh-hant": "{count} 種單位",
+    "ja": "{count} 種類の単位",
+    "es": "{count} unidades",
+    "en": "{count} units"
+  },
+  "conv-input-value": {
+    "zh-cn": "输入数值",
+    "zh-hant": "輸入數值",
+    "ja": "入力値",
+    "es": "Valor",
+    "en": "Input Value"
+  },
+  "conv-input-placeholder": {
+    "zh-cn": "请输入数值",
+    "zh-hant": "請輸入數值",
+    "ja": "数値を入力",
+    "es": "Ingresa un número",
+    "en": "Enter a number"
+  },
+  "conv-clear-input": {
+    "zh-cn": "清空输入",
+    "zh-hant": "清空輸入",
+    "ja": "入力をクリア",
+    "es": "Borrar entrada",
+    "en": "Clear input"
+  },
+  "conv-swap-units": {
+    "zh-cn": "交换单位",
+    "zh-hant": "交換單位",
+    "ja": "単位を入れ替え",
+    "es": "Intercambiar unidades",
+    "en": "Swap units"
+  },
+  "conv-result-label": {
+    "zh-cn": "转换结果",
+    "zh-hant": "換算結果",
+    "ja": "換算結果",
+    "es": "Resultado",
+    "en": "Result"
+  },
+  "conv-copy-result": {
+    "zh-cn": "复制结果",
+    "zh-hant": "複製結果",
+    "ja": "結果をコピー",
+    "es": "Copiar resultado",
+    "en": "Copy result"
+  },
+  "conv-iu-mass-warning": {
+    "zh-cn": "IU 和质量单位之间的换算结果仅供参考。",
+    "zh-hant": "IU 與質量單位之間的換算結果僅供參考。",
+    "ja": "IU と質量単位の換算結果は参考値です。",
+    "es": "La conversión entre IU y unidades de masa es orientativa.",
+    "en": "Conversions between IU and mass units are approximate."
+  },
+  "conv-convert": {
+    "zh-cn": "转换",
+    "zh-hant": "換算",
+    "ja": "換算",
+    "es": "Convertir",
+    "en": "Convert"
+  },
+  "conv-view-history": {
+    "zh-cn": "查看历史",
+    "zh-hant": "查看歷史",
+    "ja": "履歴を見る",
+    "es": "Ver historial",
+    "en": "View History"
+  },
+  "conv-history-title": {
+    "zh-cn": "换算历史",
+    "zh-hant": "換算歷史",
+    "ja": "換算履歴",
+    "es": "Historial de conversiones",
+    "en": "Conversion History"
+  },
+  "conv-history-storage": {
+    "zh-cn": "数据仅存储在浏览器本地，不会上传到服务器",
+    "zh-hant": "資料僅儲存於瀏覽器本機，不會上傳至伺服器",
+    "ja": "データはブラウザにのみ保存され、サーバーには送信されません",
+    "es": "Los datos se guardan solo en tu navegador, no se suben a un servidor",
+    "en": "Stored only in your browser; never uploaded"
+  },
+  "conv-history-empty": {
+    "zh-cn": "暂无换算历史",
+    "zh-hant": "尚無換算歷史",
+    "ja": "履歴がありません",
+    "es": "Sin historial",
+    "en": "No history yet"
+  },
+  "conv-unknown-hormone": {
+    "zh-cn": "未知激素",
+    "zh-hant": "未知荷爾蒙",
+    "ja": "不明なホルモン",
+    "es": "Hormona desconocida",
+    "en": "Unknown hormone"
+  },
+  "conv-clear": {
+    "zh-cn": "清空",
+    "zh-hant": "清空",
+    "ja": "クリア",
+    "es": "Borrar",
+    "en": "Clear"
+  },
+  "conv-help": {
+    "zh-cn": "使用帮助",
+    "zh-hant": "使用說明",
+    "ja": "使い方",
+    "es": "Ayuda",
+    "en": "Help"
+  },
+  "conv-help-basic": {
+    "zh-cn": "基本操作",
+    "zh-hant": "基本操作",
+    "ja": "基本操作",
+    "es": "Uso básico",
+    "en": "Basic Usage"
+  },
+  "conv-help-step1": {
+    "zh-cn": "选择激素类型",
+    "zh-hant": "選擇荷爾蒙類型",
+    "ja": "ホルモンを選択",
+    "es": "Selecciona la hormona",
+    "en": "Select a hormone"
+  },
+  "conv-help-step2": {
+    "zh-cn": "输入数值和选择单位",
+    "zh-hant": "輸入數值並選擇單位",
+    "ja": "数値を入力し単位を選択",
+    "es": "Introduce un valor y elige unidades",
+    "en": "Enter a value and pick units"
+  },
+  "conv-help-step3": {
+    "zh-cn": "查看自动转换结果",
+    "zh-hant": "查看自動換算結果",
+    "ja": "自動換算結果を確認",
+    "es": "Mira el resultado automático",
+    "en": "View the auto-converted result"
+  },
+  "conv-help-step4": {
+    "zh-cn": "点击复制按钮复制结果",
+    "zh-hant": "點擊複製按鈕複製結果",
+    "ja": "コピーボタンで結果をコピー",
+    "es": "Pulsa copiar para copiar el resultado",
+    "en": "Click Copy to copy the result"
+  },
+  "conv-help-ranges-title": {
+    "zh-cn": "范围提示",
+    "zh-hant": "範圍提示",
+    "ja": "範囲ガイド",
+    "es": "Rangos",
+    "en": "Range hints"
+  },
+  "conv-help-ranges-text": {
+    "zh-cn": "转换结果有时会显示颜色标识，表示数值是否属于特定的参考范围。请注意这些范围仅供参考，具体请咨询医生。",
+    "zh-hant": "換算結果有時會顯示顏色標示，表示數值是否落在特定的參考範圍。請注意此資訊僅供參考，請諮詢醫師。",
+    "ja": "換算結果には参考範囲を示す色が付くことがあります。あくまで参考値ですので、必ず医師にご相談ください。",
+    "es": "A veces el resultado muestra colores que indican si el valor cae en un rango de referencia. Es solo orientativo; consulta siempre a un médico.",
+    "en": "Results may be color-coded to indicate reference ranges. These are only orientative; always consult your physician."
+  },
+  "conv-reference-ranges": {
+    "zh-cn": "参考范围说明",
+    "zh-hant": "參考範圍說明",
+    "ja": "参考範囲",
+    "es": "Rangos de referencia",
+    "en": "Reference Ranges"
+  },
+  "conv-no-ranges": {
+    "zh-cn": "暂无参考范围",
+    "zh-hant": "尚無參考範圍",
+    "ja": "参考範囲なし",
+    "es": "Sin rangos disponibles",
+    "en": "No reference ranges"
+  },
+  "conv-data-source": {
+    "zh-cn": "数据来源",
+    "zh-hant": "資料來源",
+    "ja": "出典",
+    "es": "Fuente",
+    "en": "Source"
+  },
+  "conv-converted-from": {
+    "zh-cn": "转换自",
+    "zh-hant": "換算自",
+    "ja": "換算元",
+    "es": "Convertido desde",
+    "en": "Converted from"
+  },
+  "conv-common-units": {
+    "zh-cn": "常用单位",
+    "zh-hant": "常用單位",
+    "ja": "よく使う単位",
+    "es": "Unidades comunes",
+    "en": "Common units"
+  },
+  "conv-other-units": {
+    "zh-cn": "其他单位",
+    "zh-hant": "其他單位",
+    "ja": "その他の単位",
+    "es": "Otras unidades",
+    "en": "Other units"
+  },
+  "conv-anomalous-value": {
+    "zh-cn": "数值异常",
+    "zh-hant": "數值異常",
+    "ja": "異常値",
+    "es": "Valor anómalo",
+    "en": "Anomalous value"
+  },
+  "conv-anomalous-desc": {
+    "zh-cn": "偏离正常值过多，请检查输入是否正确",
+    "zh-hant": "偏離正常值過多，請檢查輸入是否正確",
+    "ja": "正常範囲から大きく外れています。入力をご確認ください",
+    "es": "Demasiado lejos del rango normal; revisa los datos",
+    "en": "Far outside the expected range; please check your input"
+  },
+  "雌二醇 (E2)": {
+    "zh-cn": "雌二醇 (E2)",
+    "zh-hant": "雌二醇 (E2)",
+    "ja": "エストラジオール (E2)",
+    "es": "Estradiol (E2)",
+    "en": "Estradiol (E2)"
+  },
+  "睾酮 (T)": {
+    "zh-cn": "睾酮 (T)",
+    "zh-hant": "睪酮 (T)",
+    "ja": "テストステロン (T)",
+    "es": "Testosterona (T)",
+    "en": "Testosterone (T)"
+  },
+  "泌乳素 (PRL)": {
+    "zh-cn": "泌乳素 (PRL)",
+    "zh-hant": "泌乳素 (PRL)",
+    "ja": "プロラクチン (PRL)",
+    "es": "Prolactina (PRL)",
+    "en": "Prolactin (PRL)"
+  },
+  "孕酮 (P4)": {
+    "zh-cn": "孕酮 (P4)",
+    "zh-hant": "孕酮 (P4)",
+    "ja": "プロゲステロン (P4)",
+    "es": "Progesterona (P4)",
+    "en": "Progesterone (P4)"
+  },
+  "卵泡刺激素 (FSH)": {
+    "zh-cn": "卵泡刺激素 (FSH)",
+    "zh-hant": "濾泡刺激素 (FSH)",
+    "ja": "卵胞刺激ホルモン (FSH)",
+    "es": "Hormona folículoestimulante (FSH)",
+    "en": "Follicle-Stimulating Hormone (FSH)"
+  },
+  "促黄体素 (LH)": {
+    "zh-cn": "促黄体素 (LH)",
+    "zh-hant": "促黃體素 (LH)",
+    "ja": "黄体形成ホルモン (LH)",
+    "es": "Hormona luteinizante (LH)",
+    "en": "Luteinizing Hormone (LH)"
+  },
+  "男性参考范围": {
+    "zh-cn": "男性参考范围",
+    "zh-hant": "男性參考範圍",
+    "ja": "男性の参考範囲",
+    "es": "Rango de referencia masculino",
+    "en": "Male reference range"
+  },
+  "女性参考范围": {
+    "zh-cn": "女性参考范围",
+    "zh-hant": "女性參考範圍",
+    "ja": "女性の参考範囲",
+    "es": "Rango de referencia femenino",
+    "en": "Female reference range"
+  },
+  "非针剂女性向 GAHT 目标范围": {
+    "zh-cn": "非针剂女性向 GAHT 目标范围",
+    "zh-hant": "非針劑女性向 GAHT 目標範圍",
+    "ja": "非注射剤の女性化 GAHT 目標範囲",
+    "es": "Rango objetivo de GAHT feminizante (no inyectable)",
+    "en": "Feminizing GAHT target range (non-injectable)"
+  },
+  "女性向 GAHT 目标范围": {
+    "zh-cn": "女性向 GAHT 目标范围",
+    "zh-hant": "女性向 GAHT 目標範圍",
+    "ja": "女性化 GAHT 目標範囲",
+    "es": "Rango objetivo de GAHT feminizante",
+    "en": "Feminizing GAHT target range"
+  },
+  "女性卵泡期": {
+    "zh-cn": "女性卵泡期",
+    "zh-hant": "女性卵泡期",
+    "ja": "女性 卵胞期",
+    "es": "Fase folicular (femenino)",
+    "en": "Follicular phase (female)"
+  },
+  "女性黄体期": {
+    "zh-cn": "女性黄体期",
+    "zh-hant": "女性黃體期",
+    "ja": "女性 黄体期",
+    "es": "Fase lútea (femenino)",
+    "en": "Luteal phase (female)"
+  },
+  "显著升高": {
+    "zh-cn": "显著升高",
+    "zh-hant": "顯著升高",
+    "ja": "著しく上昇",
+    "es": "Significativamente elevado",
+    "en": "Significantly elevated"
+  },
+  "绝经后女性": {
+    "zh-cn": "绝经后女性",
+    "zh-hant": "停經後女性",
+    "ja": "閉経後女性",
+    "es": "Mujer posmenopáusica",
+    "en": "Postmenopausal female"
+  },
+  "数值异常": {
+    "zh-cn": "数值异常",
+    "zh-hant": "數值異常",
+    "ja": "異常値",
+    "es": "Valor anómalo",
+    "en": "Anomalous value"
+  },
+  "需要注意": {
+    "zh-cn": "需要注意",
+    "zh-hant": "需要注意",
+    "ja": "注意が必要",
+    "es": "Requiere atención",
+    "en": "Requires attention"
+  },
+  "偏离正常值过多，请检查输入是否正确": {
+    "zh-cn": "偏离正常值过多，请检查输入是否正确",
+    "zh-hant": "偏離正常值過多，請檢查輸入是否正確",
+    "ja": "正常範囲から大きく外れています。入力をご確認ください",
+    "es": "Demasiado lejos del rango normal; revisa los datos",
+    "en": "Far outside the expected range; please check your input"
+  },
+  "HRT 综述 - MtF.wiki": {
+    "zh-cn": "HRT 综述 - MtF.wiki",
+    "zh-hant": "HRT 綜述 - MtF.wiki",
+    "ja": "HRT 概論 - MtF.wiki",
+    "es": "Resumen de TRH - MtF.wiki",
+    "en": "HRT Overview - MtF.wiki"
+  },
+  "治疗期间的监测 - MtF.wiki": {
+    "zh-cn": "治疗期间的监测 - MtF.wiki",
+    "zh-hant": "治療期間的監測 - MtF.wiki",
+    "ja": "治療中のモニタリング - MtF.wiki",
+    "es": "Monitoreo durante el tratamiento - MtF.wiki",
+    "en": "Monitoring during treatment - MtF.wiki"
+  },
+  "time-just-now": {
+    "zh-cn": "刚刚",
+    "zh-hant": "剛剛",
+    "ja": "たった今",
+    "es": "Ahora",
+    "en": "Just now"
+  },
+  "time-minutes-ago": {
+    "zh-cn": "{n}分钟前",
+    "zh-hant": "{n} 分鐘前",
+    "ja": "{n} 分前",
+    "es": "Hace {n} min",
+    "en": "{n} min ago"
+  },
+  "time-hours-ago": {
+    "zh-cn": "{n}小时前",
+    "zh-hant": "{n} 小時前",
+    "ja": "{n} 時間前",
+    "es": "Hace {n} h",
+    "en": "{n} h ago"
+  },
+  "time-days-ago": {
+    "zh-cn": "{n}天前",
+    "zh-hant": "{n} 天前",
+    "ja": "{n} 日前",
+    "es": "Hace {n} d",
+    "en": "{n} d ago"
   }
 }


### PR DESCRIPTION
## Summary

Both `/cup-calculator` and `/converter` were previously hardcoded in zh-cn and registered only for zh-cn (and zh-hant for converter) via `generateStaticParams`. They are now reachable from all 5 supported languages — `/zh-cn`, `/zh-hant`, `/ja`, `/en`, `/es` — with full UI translation.

之前 `/cup-calculator` 与 `/converter` 两个工具页面的界面文案直接硬编码为简体中文，且 `generateStaticParams` 只覆盖 zh-cn（converter 还有 zh-hant）。本 PR 将它们扩展至全部 5 种语言：zh-cn / zh-hant / ja / en / es，并补全完整的 UI 翻译。

## Changes

- **Translations** (`apps/wiki/lib/i18n/translations/translations.json`): adds ~80 new keys (`cup-*`, `conv-*`, `time-*`) plus passthrough entries keyed by the existing Chinese strings, so converter `lib/constants.ts` (hormone names, range labels, source link names, descriptions) can be translated via `t()` without restructuring.
- **Cup calculator** (`apps/wiki/app/[language]/cup-calculator/`):
  - `page.tsx`: `generateStaticParams` covers all 5 languages; metadata title and footer (privacy / disclaimer / algorithm) use `t()`.
  - `lib/utils.ts` returns a `messageKey` instead of a hardcoded Chinese string; the `{size}` placeholder is filled in the component.
  - `lib/constants.ts` `CUP_SIZES` use `messageKey` instead of `message`.
  - `CupCalculator` and `HistoryPanel` accept a `language` prop and use `t()` for steps, results, history labels, and reset/clear confirms.
  - Localized `formatTimestamp` (locale-aware `toLocaleDateString`).
- **Converter** (`apps/wiki/app/[language]/converter/`):
  - `page.tsx`: `generateStaticParams` covers all 5 languages; metadata title, intro link, and footer (note / storage) use `t()`.
  - `HormoneConverter`, `HormoneCard`, `ReferenceRanges`, `HelpTooltip`, `HistoryPanel`, `RangeIndicator`, `UnitSelector`, `ConversionTooltip` accept a `language` prop.
  - Hormone names, range labels, range descriptions, and source link names are looked up via `t(value as TranslationKey, language)` against passthrough entries; `lib/constants.ts` is unchanged.
  - Source links rewrite `/zh-cn/docs/...` → `/{lang}/docs/...`.
  - `formatTimestamp` localizes the relative-time strings (`刚刚` → `Just now`, `{n} 分钟前` → `{n} min ago`, etc.) and falls back to the appropriate `toLocaleDateString` locale.

## Notes

- Hormone unit dropdowns already showed only the symbol/displayName (e.g. `pg/mL`, `pmol/L`), not the Chinese unit name from `lib/constants.ts`, so unit listings remain language-neutral.
- Code comments inside `RangeIndicator`/`UnitSelector` are still in zh-cn; they are internal-only and out of scope here.
- Reference-range source links point to docs paths (`/{lang}/docs/medicine/monitoring`, `/{lang}/docs/medicine/overview`); these pages need to exist in each language for the links to resolve, which is independent of this PR.

## Test plan

- [x] `bunx tsc --noEmit` — passes
- [x] `pnpm --filter wiki dev` — boots cleanly
- [x] All 10 page combinations return HTTP 200: `/{zh-cn,zh-hant,ja,en,es}/{cup-calculator,converter}`
- [x] Spot-checked rendered HTML headings: `Cup Calculator` (en), `ホルモン換算` / `エストラジオール (E2)` / `参考範囲` (ja), `Conversor de hormonas` / `Estradiol (E2)` / `Rangos de referencia` (es)
- [ ] Manual click-through in browser for each language to verify form interactions and history modals (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)